### PR TITLE
Updated POTFILES.in for GTK translations

### DIFF
--- a/gtk/po/POTFILES.in
+++ b/gtk/po/POTFILES.in
@@ -2,7 +2,8 @@ src/gtk_binding.cpp
 src/gtk_cheat.cpp
 src/gtk_config.cpp
 src/gtk_display_driver_opengl.cpp
+src/gtk_netplay.cpp
 src/gtk_preferences.cpp
 src/gtk_s9x.cpp
 src/gtk_s9xwindow.cpp
-src/snes9x.glade
+src/snes9x.ui


### PR DESCRIPTION
 While working on packaging for Debian, I discovered this discrepancy. intltool-update won't warn you about it unless you are running with the -m flag to find all files with translations, and not just those in POTFILES.in.
