### PR TITLE
Win32: add notice on removal of DirectDraw in recent DX APIs

### DIFF
--- a/win32/docs/how2compile.txt
+++ b/win32/docs/how2compile.txt
@@ -8,6 +8,8 @@ NOTE: Unicode support requires a special zlib build - see the end of the zlib en
   your own project file for earlier MSVC versions
 
 - A recent DirectX SDK. The official binary is compiled against the June 2008 SDK.
+  Note that as of the June 2010 release of the DirectX SDK, DirectDraw (which is 
+  necessary to compile) has been removed.
 
 - zlib(optional) - The release binaries are built against a static zlib compiled
   against VC's multi-threaded C runtime and renamed to zlibmt.lib, to avoid linker conflicts.


### PR DESCRIPTION
The Win32 port seems to require DirectDraw; as of the June 2010 release of
the DirectX API, ddraw.h and ddraw.lib are no longer included
(http://blogs.msdn.com/b/chuckw/archive/2010/06/16/wither-directdraw.aspx)
