### PR TITLE
Win32: handle lack of libpng

### DIFF
--- a/win32/CGLCG.cpp
+++ b/win32/CGLCG.cpp
@@ -525,6 +525,7 @@ void CGLCG::setShaderVars(int pass)
 	}
 }
 
+#ifdef HAVE_LIBPNG
 bool CGLCG::loadPngImage(const TCHAR *name, int &outWidth, int &outHeight, bool &outHasAlpha, GLubyte **outData) {
     png_structp png_ptr;
     png_infop info_ptr;
@@ -644,6 +645,12 @@ bool CGLCG::loadPngImage(const TCHAR *name, int &outWidth, int &outHeight, bool 
     /* That's it */
     return true;
 }
+#else
+bool CGLCG::loadPngImage(const TCHAR *name, int &outWidth, int &outHeight, bool &outHasAlpha, GLubyte **outData) {
+	/* No PNG support */
+	return false;
+}
+#endif
 
 bool CGLCG::loadTGA(const TCHAR *filename, STGA& tgaFile)
 {


### PR DESCRIPTION
Similar to previous patch -- build failed when HAVE_LIBPNG was not set and libpng was not linked.
