### PR TITLE
Mac: fix typos in help (reflect fixes in Win32 readme)

### DIFF
--- a/macosx/English.lproj/Snes9x Help/pgs/01.html
+++ b/macosx/English.lproj/Snes9x Help/pgs/01.html
@@ -14,11 +14,11 @@
 			Snes9x is a portable, freeware Super Nintendo Entertainment System (SNES) emulator. It basically allows you to play most games designed for the SNES and Super Famicom Nintendo game systems on your Mac, Linux, Windows and so on. The games include some real gems that were only ever released in Japan.
 		</p>
 		<p>
-			The original Snes9x project was founded by Gary Henderson and Jerremy Koot as a collaboration of their earlier attempts at SNES emulation (Snes96 and Snes97.) Over the years the project has grown and has collected some of the greatest talent in the emulation community (at least of the SNES variety) some of which have been listed in the credits section, others have helped but have been loss in the course of time.
+			The original Snes9x project was founded by Gary Henderson and Jerremy Koot as a collaboration of their earlier attempts at SNES emulation (Snes96 and Snes97.) Over the years the project has grown and has collected some of the greatest talent in the emulation community (at least of the SNES variety) some of which have been listed in the credits section, others have helped but have been lost in the course of time.
 		</p>
 		<h3>Why Emulate the SNES?</h3>
 		<p>
-			Well, there are many reasons for this. The main reason is for nostalgic purposes. In this day and age, it's hard to find an SNES and many good games. Plus, many of us over the course of time have lost our beloved consoles (may they R.I.P) but still have our original carts. With no other means to play them, we turn to emulators. Besides this there are many conveniences of doing this on the computer instead of dragging out your old system.
+			Well, there are many reasons for this. The main reason is for nostalgic purposes. In this day and age, it's hard to find a SNES and many good games. Plus, many of us over the course of time have lost our beloved consoles (may they R.I.P) but still have our original carts. With no other means to play them, we turn to emulators. Besides this there are many conveniences of doing this on the computer instead of dragging out your old system.
 		</p>
 		<h4>Advantages consist of :</h4>
 		<ul>

--- a/macosx/English.lproj/Snes9x Help/pgs/02.html
+++ b/macosx/English.lproj/Snes9x Help/pgs/02.html
@@ -60,7 +60,7 @@
 			When asking for help on the Snes9x forums, please list the color and CRC32 that is displayed. This will help to find out what the problem is.
 		</p>
 		<p>
-			These colors do NOT signify whether a game will work or not. It is just a means for reference so we can understand what may or may not be a problem. Most often the problem with games that don't work it's because they are corrupt or are a bad dump and should be redumped.
+			These colors do NOT signify whether a game will work or not. It is just a means for reference so we can understand what may or may not be a problem. Most often the problem with games that don't work is that they are corrupt or are a bad dump and should be redumped.
 		</p>
 		<h3>SNES Joypad Emulation</h3>
 		<p>

--- a/macosx/English.lproj/Snes9x Help/pgs/03.html
+++ b/macosx/English.lproj/Snes9x Help/pgs/03.html
@@ -17,7 +17,7 @@
 			G-Force/ATI Rage 128 or later
 		</p>
 		<p>
-			Certain games use added hardware which will require a faster Mac. The specs listed above is the minimum to use Snes9x in any playable form. It is recommended that you get a semi-modern Mac with a 800MHz PowerPC processor if you want good results. A 1GHz PowerPC or Intel Mac is recommended for those that want a near perfect experience.
+			Certain games use added hardware which will require a faster Mac. The specs listed above are the minimum to use Snes9x in any playable form. It is recommended that you get a semi-modern Mac with a 800MHz PowerPC processor if you want good results. A 1GHz PowerPC or Intel Mac is recommended for those that want a near perfect experience.
 		</p>
 		<h3>Software</h3>
 		<p>

--- a/macosx/English.lproj/Snes9x Help/pgs/08.html
+++ b/macosx/English.lproj/Snes9x Help/pgs/08.html
@@ -15,15 +15,15 @@
 		<p>
 			Snes9x also supports QuickTime export feature. Your realtime play or the recorded movie is exported to a QuickTime movie file.
 		</p>
-		<h3>Recording the Movie</h3>
+		<h3>Recording a Movie</h3>
 		<p>
 			To record a movie, choose 'Record Movie...' in 'Option' menu and choose the location where the movie file (.smv) will be saved. Here you can decide when to start recording. If you want to record from the very start of a game, turn on 'Reset' check box. If you want to start recording from where you are already in a game, turn it off. You can also choose which players to be recorded. If you are playing by yourself leave 1P as the only one selected. The more players you choose to be recorded the larger the file size will be. To stop recording, pause the game.
 		</p>
-		<h3>Playing Back the Movie</h3>
+		<h3>Playing Back a Movie</h3>
 		<p>
 			To play back the movie you recorded, choose 'Play Movie...' in 'Option' menu and choose the movie file. Make sure the movie was recorded with the same ROM that you have loaded.
 		</p>
-		<h3>Re-recording the Movie</h3>
+		<h3>Re-recording a Movie</h3>
 		<p>
 			If you make a mistake while recording a movie, there is a movie re-record function. Simply freeze/defrost a game state anytime while recording. To re-record the movie that has already finished recording, choose 'Play Movie...' in 'Option' menu, turn off 'Read Only' check box, defrost during playing the movie, and it changes to re-recording mode.
 		</p>

--- a/macosx/English.lproj/Snes9x Help/pgs/12.html
+++ b/macosx/English.lproj/Snes9x Help/pgs/12.html
@@ -44,7 +44,7 @@
 				</tbody>
 			</table></li>
 		</ul>
-		<h3>Problems with Sounds</h3>
+		<h3>Problems with Sound</h3>
 		<p>
 			If you hear crackling noise during the game, try the following to eliminate the noise:
 		</p>


### PR DESCRIPTION
Mac version of d53b71583cca5e7ba0deefe316d49903c2ceebe6
