### PR TITLE
Gtk : Fix Mutex problem

### DIFF
--- a/gtk/src/gtk_s9x.cpp
+++ b/gtk/src/gtk_s9x.cpp
@@ -44,6 +44,7 @@ main (int argc, char *argv[])
 
     g_thread_init (NULL);
     gdk_threads_init ();
+    gdk_threads_enter ();
 
     gtk_init (&argc, &argv);
 
@@ -126,7 +127,7 @@ main (int argc, char *argv[])
     gtk_window_present (top_level->get_window ());
 
     gtk_main ();
-
+    gdk_threads_leave ();
     return 0;
 }
 


### PR DESCRIPTION
I fixed a problem with glib > 2.41 during the compilation.
See https://bugzilla.gnome.org/show_bug.cgi?id=735428