### PR TITLE
BS-X Code Refactor and Cleanup

### DIFF
--- a/bsx.cpp
+++ b/bsx.cpp
@@ -671,7 +671,7 @@ static void BSX_Map (void)
 	Memory.map_WriteProtectROM();
 }
 
-static uint8 BSX_Get_Bypass_FlashIO (uint16 offset)
+static uint8 BSX_Get_Bypass_FlashIO (uint32 offset)
 {
 	MapROM = FlashROM = Memory.ROM + Multi.cartOffsetB;
 
@@ -681,7 +681,7 @@ static uint8 BSX_Get_Bypass_FlashIO (uint16 offset)
 		return (MapROM[(offset & 0x1F0000) >> 1 | (offset & 0x7FFF)]);
 }
 
-static void BSX_Set_Bypass_FlashIO (uint16 offset, uint8 byte)
+static void BSX_Set_Bypass_FlashIO (uint32 offset, uint8 byte)
 {
 	MapROM = FlashROM = Memory.ROM + Multi.cartOffsetB;
 
@@ -856,8 +856,8 @@ void S9xSetBSX (uint8 byte, uint32 address)
 						case 0x20D0: //Block Erase
 							uint32 x;
 							for (x = 0; x < 0x10000; x++) {
-								BSX_Set_Bypass_FlashIO(((address & 0xFF0000) + x), 0xFF);
-								//MapROM[((address & 0xFF0000) - 0xC00000) + x] = 0xFF;
+								//BSX_Set_Bypass_FlashIO(((address & 0xFF0000) + x), 0xFF);
+								MapROM[(address & 0x0F0000) + x] = 0xFF;
 							}
 							break;
 
@@ -866,8 +866,8 @@ void S9xSetBSX (uint8 byte, uint32 address)
 							{
 								uint32 x;
 								for (x = 0; x < FLASH_SIZE; x++) {
-									BSX_Set_Bypass_FlashIO(x, 0xFF);
-									//MapROM[x] = 0xFF;
+									//BSX_Set_Bypass_FlashIO(x, 0xFF);
+									MapROM[x] = 0xFF;
 								}
 							}
 							break;

--- a/bsx.cpp
+++ b/bsx.cpp
@@ -673,18 +673,22 @@ static void BSX_Map (void)
 
 static uint8 BSX_Get_Bypass_FlashIO (uint16 offset)
 {
+	MapROM = FlashROM = Memory.ROM + Multi.cartOffsetB;
+
 	if (BSX.MMC[0x02])
 		return (MapROM[offset & 0x0FFFFF]);
 	else
-		return (MapROM[(offset & 0x0F0000) >> 1 | (offset & 0x7FFF)]);
+		return (MapROM[(offset & 0x1F0000) >> 1 | (offset & 0x7FFF)]);
 }
 
 static void BSX_Set_Bypass_FlashIO (uint16 offset, uint8 byte)
 {
+	MapROM = FlashROM = Memory.ROM + Multi.cartOffsetB;
+
 	if (BSX.MMC[0x02])
 		MapROM[offset & 0x0FFFFF] = byte;
 	else
-		MapROM[(offset & 0x0F0000) >> 1 | (offset & 0x7FFF)] = byte;
+		MapROM[(offset & 0x1F0000) >> 1 | (offset & 0x7FFF)] = byte;
 }
 
 uint8 S9xGetBSX (uint32 address)

--- a/bsx.cpp
+++ b/bsx.cpp
@@ -686,9 +686,9 @@ static void BSX_Set_Bypass_FlashIO (uint32 offset, uint8 byte)
 	MapROM = FlashROM = Memory.ROM + Multi.cartOffsetB;
 
 	if (BSX.MMC[0x02])
-		MapROM[offset & 0x0FFFFF] = byte;
+		MapROM[offset & 0x0FFFFF] = MapROM[offset & 0x0FFFFF] & byte;
 	else
-		MapROM[(offset & 0x1F0000) >> 1 | (offset & 0x7FFF)] = byte;
+		MapROM[(offset & 0x1F0000) >> 1 | (offset & 0x7FFF)] = MapROM[(offset & 0x1F0000) >> 1 | (offset & 0x7FFF)] & byte;
 }
 
 uint8 S9xGetBSX (uint32 address)
@@ -857,7 +857,10 @@ void S9xSetBSX (uint8 byte, uint32 address)
 							uint32 x;
 							for (x = 0; x < 0x10000; x++) {
 								//BSX_Set_Bypass_FlashIO(((address & 0xFF0000) + x), 0xFF);
-								MapROM[(address & 0x0F0000) + x] = 0xFF;
+								if (BSX.MMC[0x02])
+									MapROM[(address & 0x0F0000) + x] = 0xFF;
+								else
+									MapROM[((address & 0x1E0000) >> 1) + x] = 0xFF;
 							}
 							break;
 

--- a/bsx.h
+++ b/bsx.h
@@ -199,6 +199,11 @@ struct SBSX
 	uint8	MMC[16];
 	uint8	prevMMC[16];
 	uint8	test2192[32];
+
+	bool	flash_csr;
+	bool	flash_gsr;
+	bool	flash_bsr;
+	bool	flash_cmd_done;
 };
 
 extern struct SBSX	BSX;

--- a/gtk/src/gtk_file.cpp
+++ b/gtk/src/gtk_file.cpp
@@ -422,7 +422,7 @@ S9xOpenROMDialog (void)
     {
             "*.smc", "*.SMC", "*.fig", "*.FIG", "*.sfc", "*.SFC",
             "*.jma", "*.JMA", "*.zip", "*.ZIP", "*.gd3", "*.GD3",
-            "*.swc", "*.SWC", "*.gz" , "*.GZ",
+            "*.swc", "*.SWC", "*.gz" , "*.GZ", "*.bs", "*.BS",
             NULL
     };
 

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -178,7 +178,7 @@ void retro_get_system_info(struct retro_system_info *info)
 
     info->library_name = "Snes9x";
     info->library_version = VERSION;
-    info->valid_extensions = "smc|sfc|swc|fig";
+    info->valid_extensions = "smc|sfc|swc|fig|bs";
     info->need_fullpath = false;
     info->block_extract = false;
 }

--- a/memmap.cpp
+++ b/memmap.cpp
@@ -2002,6 +2002,15 @@ bool8 CMemory::LoadBSCart ()
 
 	CalculatedSize = Multi.cartSizeA;
 
+	if (Multi.cartSizeB == 0 && Multi.cartSizeA <= (MAX_ROM_SIZE - 0x100000))
+	{
+		//Initialize 1MB Empty Memory Pack only if cart B is cleared
+		//It does not make a Memory Pack if game is loaded like a normal ROM
+		Multi.cartOffsetB = CalculatedSize;
+		Multi.cartSizeB = 0x100000;
+		memset(Memory.ROM + Multi.cartOffsetB, 0xFF, 0x100000);
+	}
+
 	return (TRUE);
 }
 

--- a/memmap.cpp
+++ b/memmap.cpp
@@ -3403,8 +3403,7 @@ void CMemory::Map_BSCartLoROMMap(uint8 mapping)
 	}
 
 	map_LoROMSRAM();
-	map_index(0xc0, 0xef, 0x0000, 0x7fff, MAP_BSX, MAP_TYPE_RAM);
-	map_index(0xc0, 0xef, 0x8000, 0xffff, MAP_BSX, MAP_TYPE_RAM);
+	map_index(0xc0, 0xef, 0x0000, 0xffff, MAP_BSX, MAP_TYPE_RAM);
 	map_WRAM();
 
 	map_WriteProtectROM();

--- a/memmap.cpp
+++ b/memmap.cpp
@@ -2002,11 +2002,11 @@ bool8 CMemory::LoadBSCart ()
 
 	CalculatedSize = Multi.cartSizeA;
 
-	if (Multi.cartSizeB == 0 && Multi.cartSizeA <= (MAX_ROM_SIZE - 0x100000))
+	if (Multi.cartSizeB == 0 && Multi.cartSizeA <= (MAX_ROM_SIZE - 0x100000 - Multi.cartOffsetA))
 	{
 		//Initialize 1MB Empty Memory Pack only if cart B is cleared
 		//It does not make a Memory Pack if game is loaded like a normal ROM
-		Multi.cartOffsetB = CalculatedSize;
+		Multi.cartOffsetB = Multi.cartOffsetA + CalculatedSize;
 		Multi.cartSizeB = 0x100000;
 		memset(Memory.ROM + Multi.cartOffsetB, 0xFF, 0x100000);
 	}

--- a/memmap.cpp
+++ b/memmap.cpp
@@ -2210,6 +2210,32 @@ bool8 CMemory::SaveSRAM (const char *filename)
 	return (FALSE);
 }
 
+bool8 CMemory::SaveMPAK (const char *filename)
+{
+	if (Settings.BS || (Multi.cartSizeB && (Multi.cartType == 3)))
+	{
+		FILE	*file;
+		int		size;
+		char	mempakName[PATH_MAX + 1];
+
+		strcpy(mempakName, filename);
+		size = 0x100000;
+		if (size)
+		{
+			file = fopen(mempakName, "wb");
+			if (file)
+			{
+				size_t	ignore;
+				ignore = fwrite((char *)Memory.ROM + Multi.cartOffsetB, size, 1, file);
+				fclose(file);
+
+				return (TRUE);
+			}
+		}
+	}
+	return (FALSE);
+}
+
 // initialization
 
 static uint32 caCRC32 (uint8 *array, uint32 size, uint32 crc32)

--- a/memmap.h
+++ b/memmap.h
@@ -331,6 +331,8 @@ struct CMemory
 	void	Map_ExtendedHiROMMap (void);
 	void	Map_SameGameHiROMMap (void);
 	void	Map_SPC7110HiROMMap (void);
+	void	Map_BSCartLoROMMap(uint8);
+	void	Map_BSCartHiROMMap(void);
 
 	uint16	checksum_calc_sum (uint8 *, uint32);
 	uint16	checksum_mirror_sum (uint8 *, uint32 &, uint32 mask = 0x800000);

--- a/memmap.h
+++ b/memmap.h
@@ -284,7 +284,7 @@ struct CMemory
 	bool8	LoadMultiCart (const char *, const char *);
     bool8	LoadMultiCartInt ();
 	bool8	LoadSufamiTurbo ();
-	bool8	LoadSameGame ();
+	bool8	LoadBSCart ();
 	bool8	LoadGNEXT ();
 	bool8	LoadSRAM (const char *);
 	bool8	SaveSRAM (const char *);
@@ -326,10 +326,9 @@ struct CMemory
 	void	Map_SetaDSPLoROMMap (void);
 	void	Map_SDD1LoROMMap (void);
 	void	Map_SA1LoROMMap (void);
-	void	Map_GNEXTSA1LoROMMap (void);
+	void	Map_BSSA1LoROMMap (void);
 	void	Map_HiROMMap (void);
 	void	Map_ExtendedHiROMMap (void);
-	void	Map_SameGameHiROMMap (void);
 	void	Map_SPC7110HiROMMap (void);
 	void	Map_BSCartLoROMMap(uint8);
 	void	Map_BSCartHiROMMap(void);

--- a/memmap.h
+++ b/memmap.h
@@ -291,6 +291,7 @@ struct CMemory
 	void	ClearSRAM (bool8 onlyNonSavedSRAM = 0);
 	bool8	LoadSRTC (void);
 	bool8	SaveSRTC (void);
+	bool8	SaveMPAK (const char *);
 
 	char *	Safe (const char *);
 	char *	SafeANK (const char *);

--- a/sa1.cpp
+++ b/sa1.cpp
@@ -337,7 +337,7 @@ static void S9xSetSA1MemMap (uint32 which1, uint8 map)
 			}
 			else
 			{
-				offset = ((((map & 0x80) ? map : which1) & 7) - 4) * 0x100000 + (c << 11) - 0x8000;
+				offset = (((map & 0x80) ? (map - 4) : which1) & 7) * 0x100000 + (c << 11) - 0x8000;
 				block = Memory.ROM + Multi.cartOffsetB + offset;
 			}			
 		}

--- a/sa1.cpp
+++ b/sa1.cpp
@@ -304,7 +304,16 @@ static void S9xSetSA1MemMap (uint32 which1, uint8 map)
 
 	for (int c = 0; c < 0x100; c += 16)
 	{
-		uint8	*block = &Memory.ROM[(map & 7) * 0x100000 + (c << 12)];
+		uint8 *block;
+		if (Multi.cartType != 5)
+			block = &Memory.ROM[(map & 7) * 0x100000 + (c << 12)];
+		else
+		{
+			if ((map & 7) < 4)
+				block = Memory.ROM + Multi.cartOffsetA + ((map & 7) * 0x100000 + (c << 12));
+			else
+				block = Memory.ROM + Multi.cartOffsetB + (((map & 7) - 4) * 0x100000 + (c << 12));
+		}
 		for (int i = c; i < c + 16; i++)
 			Memory.Map[start  + i] = SA1.Map[start  + i] = block;
 	}
@@ -312,8 +321,26 @@ static void S9xSetSA1MemMap (uint32 which1, uint8 map)
 	for (int c = 0; c < 0x200; c += 16)
 	{
         // conversion to int is needed here - map is promoted but which1 is not
-        int32 offset = (((map & 0x80) ? map : which1) & 7) * 0x100000 + (c << 11) - 0x8000;
-		uint8	*block = &Memory.ROM[offset];
+		int32 offset;
+		uint8 *block;
+		if (Multi.cartType != 5)
+		{
+			offset = (((map & 0x80) ? map : which1) & 7) * 0x100000 + (c << 11) - 0x8000;
+			block = &Memory.ROM[offset];
+		}
+		else
+		{
+			if ((map & 7) < 4)
+			{
+				offset = (((map & 0x80) ? map : which1) & 7) * 0x100000 + (c << 11) - 0x8000;
+				block = Memory.ROM + Multi.cartOffsetA + offset;
+			}
+			else
+			{
+				offset = ((((map & 0x80) ? map : which1) & 7) - 4) * 0x100000 + (c << 11) - 0x8000;
+				block = Memory.ROM + Multi.cartOffsetB + offset;
+			}			
+		}
 		for (int i = c + 8; i < c + 16; i++)
 			Memory.Map[start2 + i] = SA1.Map[start2 + i] = block;
 	}

--- a/win32/rsrc/resource.h
+++ b/win32/rsrc/resource.h
@@ -496,13 +496,14 @@
 #define ID_WINDOW_SIZE_4X               40172
 #define ID_DEBUG_APU_TRACE              40173
 #define ID_EMULATION_BACKGROUNDINPUT    40174
+#define ID_SAVEMEMPACK                  40175
 
 // Next default values for new objects
 // 
 #ifdef APSTUDIO_INVOKED
 #ifndef APSTUDIO_READONLY_SYMBOLS
 #define _APS_NEXT_RESOURCE_VALUE        151
-#define _APS_NEXT_COMMAND_VALUE         40175
+#define _APS_NEXT_COMMAND_VALUE         40176
 #define _APS_NEXT_CONTROL_VALUE         3018
 #define _APS_NEXT_SYMED_VALUE           101
 #endif

--- a/win32/rsrc/snes9x.rc
+++ b/win32/rsrc/snes9x.rc
@@ -822,6 +822,7 @@ BEGIN
             MENUITEM "S&ave SPC Data",              ID_FILE_SAVE_SPC_DATA
             MENUITEM "Save Screenshot",             ID_SAVESCREENSHOT
             MENUITEM "Sa&ve S-RAM Data",            ID_FILE_SAVE_SRAM_DATA
+	        MENUITEM "Save Memory Pack",            ID_SAVEMEMPACK
         END
         MENUITEM "ROM Information...",          IDM_ROM_INFO
         MENUITEM SEPARATOR

--- a/win32/wlanguage.h
+++ b/win32/wlanguage.h
@@ -588,6 +588,8 @@ Nintendo is a trade mark.")
 
 #define INFO_SAVE_SPC "Saving SPC Data."
 
+#define MPAK_SAVE_FAILED "Failed to save Memory Pack."
+
 #define CHEATS_INFO_ENABLED "Cheats enabled."
 #define CHEATS_INFO_DISABLED "Cheats disabled."
 #define CHEATS_INFO_ENABLED_NONE "Cheats enabled. (None are active.)"

--- a/win32/wsnes9x.cpp
+++ b/win32/wsnes9x.cpp
@@ -2239,6 +2239,17 @@ LRESULT CALLBACK WinProc(
 			if(!success)
 				S9xMessage(S9X_ERROR, S9X_FREEZE_FILE_INFO, SRM_SAVE_FAILED);
 		}	break;
+		case ID_SAVEMEMPACK: {
+			const char *filename = S9xGetFilenameInc(".bs", SRAM_DIR);
+			bool8 success = Memory.SaveMPAK(filename);
+			if (!success)
+				S9xMessage(S9X_ERROR, 0, MPAK_SAVE_FAILED);
+			else
+			{
+				sprintf(String, "Saved Memory Pack %s", filename);
+				S9xMessage(S9X_INFO, 0, String);
+			}
+		}	break;
 		case ID_FILE_RESET:
 #ifdef NETPLAY_SUPPORT
 			if (Settings.NetPlayServer)

--- a/win32/wsnes9x.cpp
+++ b/win32/wsnes9x.cpp
@@ -6991,6 +6991,7 @@ void MakeExtFile(void)
 
 	out<<"smcN"<<endl<<"zipY"<<endl<<"gzY" <<endl<<"swcN"<<endl<<"figN"<<endl;
 	out<<"sfcN"<<endl;
+	out<<"bsN"<<endl;
 	out<<"jmaY";
 	out.close();
 	SetFileAttributes(TEXT("Valid.Ext"), FILE_ATTRIBUTE_ARCHIVE|FILE_ATTRIBUTE_READONLY);


### PR DESCRIPTION
I mostly want to do this pull request so we can talk about Satellaview support.

Not everything is done yet, I need to do Memory Pack loading for games like RPG Tsukuru 2 and others, and also proper Satellaview signal support, which we have to talk about since that would need to include a new folder for Satellaview specific files. I also want to do Memory Pack saving, to save custom content.

I've done it in the past with my old fork named snes9x-sx2. It did work fine before, there's no reason I wouldn't be able to implement those again.

There's one change compared to my snes9x-sx2 fork, Kirby Satellaview games are actually booting. There was an oversight where the PSRAM was mapped all over the PPU part, preventing them to do anything.