### PR TITLE
DirectDraw compile switch

### DIFF
--- a/win32/CDirectDraw.cpp
+++ b/win32/CDirectDraw.cpp
@@ -187,8 +187,7 @@
   Nintendo Co., Limited and its subsidiary companies.
  ***********************************************************************************/
 
-
-
+#if DIRECTDRAW_DEFINED
 
 // CDirectDraw.cpp: implementation of the CDirectDraw class.
 //
@@ -897,3 +896,4 @@ void CDirectDraw::EnumModes(std::vector<dMode> *modeVector)
 	lpDD->EnumDisplayModes(DDEDM_REFRESHRATES,NULL,(void *)modeVector,(LPDDENUMMODESCALLBACK)EnumModesCallback);
 }
 
+#endif

--- a/win32/CDirectDraw.h
+++ b/win32/CDirectDraw.h
@@ -203,6 +203,8 @@
 #pragma once
 #endif // _MSC_VER >= 1000
 
+#if DIRECTDRAW_DEFINED
+
 class CDirectDraw: public IS9xDisplayOutput
 {
 public:	
@@ -246,5 +248,7 @@ public:
 	CDirectDraw();
 	virtual ~CDirectDraw();
 };
+
+#endif
 
 #endif // !defined(CDIRECTDRAW_H_INCLUDED)

--- a/win32/dxerr.cpp
+++ b/win32/dxerr.cpp
@@ -17,7 +17,9 @@
 #include <algorithm>
 
 #if !defined(WINAPI_FAMILY) || (WINAPI_FAMILY == WINAPI_FAMILY_DESKTOP_APP)
+#if DIRECTDRAW_DEFINED
 #include <ddraw.h>
+#endif
 #include <d3d9.h>
 #include <dsound.h>
 
@@ -3012,6 +3014,7 @@ const WCHAR* WINAPI DXGetErrorStringW( _In_ HRESULT hr )
 // -------------------------------------------------------------
 // ddraw.h error codes
 // -------------------------------------------------------------
+#if DIRECTDRAW_DEFINED
         CHK_ERRA(DDERR_ALREADYINITIALIZED)
         CHK_ERRA(DDERR_CANNOTATTACHSURFACE)
         CHK_ERRA(DDERR_CANNOTDETACHSURFACE)
@@ -3130,6 +3133,7 @@ const WCHAR* WINAPI DXGetErrorStringW( _In_ HRESULT hr )
         CHK_ERRA(DDERR_NOMONITORINFORMATION)
         CHK_ERRA(DDERR_NODRIVERSUPPORT)
         CHK_ERRA(DDERR_DEVICEDOESNTOWNSURFACE)
+#endif
 
 // -------------------------------------------------------------
 // dinput.h error codes
@@ -6392,7 +6396,7 @@ const char* WINAPI DXGetErrorStringA(_In_ HRESULT hr)
             CHK_ERR_WIN32A(ERROR_IPSEC_IKE_NEG_STATUS_END)
 
 #if !defined(WINAPI_FAMILY) || (WINAPI_FAMILY == WINAPI_FAMILY_DESKTOP_APP)
-
+#if DIRECTDRAW_DEFINED
             // -------------------------------------------------------------
             // ddraw.h error codes
             // -------------------------------------------------------------
@@ -6514,7 +6518,7 @@ const char* WINAPI DXGetErrorStringA(_In_ HRESULT hr)
             CHK_ERRA(DDERR_NOMONITORINFORMATION)
             CHK_ERRA(DDERR_NODRIVERSUPPORT)
             CHK_ERRA(DDERR_DEVICEDOESNTOWNSURFACE)
-
+#endif
             // -------------------------------------------------------------
             // dinput.h error codes
             // -------------------------------------------------------------
@@ -6860,7 +6864,7 @@ void WINAPI DXGetErrorDescriptionW( _In_ HRESULT hr, _Out_cap_(count) WCHAR* des
 // Commmented out codes are actually alises for other codes
 
 #if !defined(WINAPI_FAMILY) || (WINAPI_FAMILY == WINAPI_FAMILY_DESKTOP_APP)
-
+#if DIRECTDRAW_DEFINED
 // -------------------------------------------------------------
 // ddraw.h error codes
 // -------------------------------------------------------------
@@ -6982,7 +6986,7 @@ void WINAPI DXGetErrorDescriptionW( _In_ HRESULT hr, _Out_cap_(count) WCHAR* des
         CHK_ERR(DDERR_NOMONITORINFORMATION, "The monitor does not have EDID data.")
         CHK_ERR(DDERR_NODRIVERSUPPORT, "The driver does not enumerate display mode refresh rates.")
         CHK_ERR(DDERR_DEVICEDOESNTOWNSURFACE, "Surfaces created by one direct draw device cannot be used directly by another direct draw device.")
-
+#endif
 
 // -------------------------------------------------------------
 // dinput.h error codes
@@ -7383,7 +7387,7 @@ void WINAPI DXGetErrorDescriptionA(_In_ HRESULT hr, _Out_cap_(count) char* desc,
         // Commmented out codes are actually alises for other codes
 
 #if !defined(WINAPI_FAMILY) || (WINAPI_FAMILY == WINAPI_FAMILY_DESKTOP_APP)
-
+#if DIRECTDRAW_DEFINED
         // -------------------------------------------------------------
         // ddraw.h error codes
         // -------------------------------------------------------------
@@ -7505,7 +7509,7 @@ void WINAPI DXGetErrorDescriptionA(_In_ HRESULT hr, _Out_cap_(count) char* desc,
             CHK_ERR(DDERR_NOMONITORINFORMATION, "The monitor does not have EDID data.")
             CHK_ERR(DDERR_NODRIVERSUPPORT, "The driver does not enumerate display mode refresh rates.")
             CHK_ERR(DDERR_DEVICEDOESNTOWNSURFACE, "Surfaces created by one direct draw device cannot be used directly by another direct draw device.")
-
+#endif
 
             // -------------------------------------------------------------
             // dinput.h error codes

--- a/win32/snes9xw.vcxproj
+++ b/win32/snes9xw.vcxproj
@@ -224,7 +224,7 @@
       <Culture>0x0409</Culture>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>comctl32.lib;winmm.lib;opengl32.lib;glu32.lib;wsock32.lib;ddraw.lib;dsound.lib;dxguid.lib;delayimp.lib;vfw32.lib;msxml2.lib;shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>comctl32.lib;winmm.lib;opengl32.lib;glu32.lib;wsock32.lib;dsound.lib;dxguid.lib;delayimp.lib;vfw32.lib;msxml2.lib;shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <AdditionalLibraryDirectories>$(ProjectDir)..\..\FMOD\api\lib;$(ProjectDir)..\..\FMODEx_x64\api\lib;$(ProjectDir)..\..\FMODEx\api\lib;$(ProjectDir)..\i386;$(ProjectDir)..\..\zlib\lib;$(ProjectDir)..\..\libPNG\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <DelayLoadDLLs>fmod.dll;fmodex.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
@@ -273,7 +273,7 @@
       <Culture>0x0409</Culture>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>comctl32.lib;winmm.lib;opengl32.lib;glu32.lib;wsock32.lib;ddraw.lib;dsound.lib;dxguid.lib;delayimp.lib;vfw32.lib;msxml2.lib;shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>comctl32.lib;winmm.lib;opengl32.lib;glu32.lib;wsock32.lib;dsound.lib;dxguid.lib;delayimp.lib;vfw32.lib;msxml2.lib;shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <AdditionalLibraryDirectories>$(ProjectDir)..\..\FMOD\api\lib;$(ProjectDir)..\..\FMODEx_x64\api\lib;$(ProjectDir)..\..\FMODEx\api\lib;$(ProjectDir)..\i386;$(ProjectDir)..\..\zlib\lib;$(ProjectDir)..\..\libPNG\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <DelayLoadDLLs>fmod.dll;fmodex64.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
@@ -317,7 +317,7 @@
       <Culture>0x0409</Culture>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>comctl32.lib;winmm.lib;opengl32.lib;glu32.lib;wsock32.lib;ddraw.lib;dsound.lib;dxguid.lib;delayimp.lib;vfw32.lib;msxml2.lib;shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>comctl32.lib;winmm.lib;opengl32.lib;glu32.lib;wsock32.lib;dsound.lib;dxguid.lib;delayimp.lib;vfw32.lib;msxml2.lib;shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <AdditionalLibraryDirectories>$(ProjectDir)..\..\FMOD\api\lib;$(ProjectDir)..\..\FMODEx_x64\api\lib;$(ProjectDir)..\..\FMODEx\api\lib;$(ProjectDir)..\i386;$(ProjectDir)..\..\zlib\lib;$(ProjectDir)..\..\libPNG\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <EnableUAC>false</EnableUAC>
@@ -363,7 +363,7 @@
       <Culture>0x0409</Culture>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>comctl32.lib;winmm.lib;opengl32.lib;glu32.lib;wsock32.lib;ddraw.lib;dsound.lib;dxguid.lib;delayimp.lib;vfw32.lib;msxml2.lib;shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>comctl32.lib;winmm.lib;opengl32.lib;glu32.lib;wsock32.lib;dsound.lib;dxguid.lib;delayimp.lib;vfw32.lib;msxml2.lib;shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <AdditionalLibraryDirectories>$(ProjectDir)..\..\FMOD\api\lib;$(ProjectDir)..\..\FMODEx_x64\api\lib;$(ProjectDir)..\..\FMODEx\api\lib;$(ProjectDir)..\i386;$(ProjectDir)..\..\zlib\lib;$(ProjectDir)..\..\libPNG\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <EnableUAC>false</EnableUAC>
@@ -409,7 +409,7 @@
       <Culture>0x0409</Culture>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>comctl32.lib;winmm.lib;opengl32.lib;glu32.lib;wsock32.lib;ddraw.lib;dsound.lib;dxguid.lib;delayimp.lib;vfw32.lib;msxml2.lib;shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>comctl32.lib;winmm.lib;opengl32.lib;glu32.lib;wsock32.lib;dsound.lib;dxguid.lib;delayimp.lib;vfw32.lib;msxml2.lib;shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <AdditionalLibraryDirectories>$(ProjectDir)..\..\FMOD\api\lib;$(ProjectDir)..\..\FMODEx_x64\api\lib;$(ProjectDir)..\..\FMODEx\api\lib;$(ProjectDir)..\i386;$(ProjectDir)..\..\zlib\lib;$(ProjectDir)..\..\libPNG\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <EnableUAC>false</EnableUAC>
@@ -456,7 +456,7 @@
       <Culture>0x0409</Culture>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>comctl32.lib;winmm.lib;opengl32.lib;glu32.lib;wsock32.lib;ddraw.lib;dsound.lib;dxguid.lib;delayimp.lib;vfw32.lib;msxml2.lib;shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>comctl32.lib;winmm.lib;opengl32.lib;glu32.lib;wsock32.lib;dsound.lib;dxguid.lib;delayimp.lib;vfw32.lib;msxml2.lib;shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <AdditionalLibraryDirectories>$(ProjectDir)..\..\FMOD\api\lib;$(ProjectDir)..\..\FMODEx_x64\api\lib;$(ProjectDir)..\..\FMODEx\api\lib;$(ProjectDir)..\i386;$(ProjectDir)..\..\zlib\lib;$(ProjectDir)..\..\libPNG\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <EnableUAC>false</EnableUAC>
@@ -509,7 +509,7 @@
       <Culture>0x0409</Culture>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>comctl32.lib;winmm.lib;opengl32.lib;glu32.lib;wsock32.lib;ddraw.lib;dsound.lib;dxguid.lib;delayimp.lib;vfw32.lib;msxml2.lib;shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>comctl32.lib;winmm.lib;opengl32.lib;glu32.lib;wsock32.lib;dsound.lib;dxguid.lib;delayimp.lib;vfw32.lib;msxml2.lib;shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <AdditionalLibraryDirectories>$(ProjectDir)..\..\FMOD\api\lib;$(ProjectDir)..\..\FMODEx_x64\api\lib;$(ProjectDir)..\..\FMODEx\api\lib;$(ProjectDir)..\i386;$(ProjectDir)..\..\zlib\lib;$(ProjectDir)..\..\libPNG\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <DelayLoadDLLs>fmod.dll;fmodex.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
@@ -560,7 +560,7 @@
       <Culture>0x0409</Culture>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>comctl32.lib;winmm.lib;opengl32.lib;glu32.lib;wsock32.lib;ddraw.lib;dsound.lib;dxguid.lib;delayimp.lib;vfw32.lib;msxml2.lib;shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>comctl32.lib;winmm.lib;opengl32.lib;glu32.lib;wsock32.lib;dsound.lib;dxguid.lib;delayimp.lib;vfw32.lib;msxml2.lib;shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <AdditionalLibraryDirectories>$(ProjectDir)..\..\FMOD\api\lib;$(ProjectDir)..\..\FMODEx_x64\api\lib;$(ProjectDir)..\..\FMODEx\api\lib;$(ProjectDir)..\i386;$(ProjectDir)..\..\zlib\lib;$(ProjectDir)..\..\libPNG\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <DelayLoadDLLs>fmod.dll;fmodex64.dll;%(DelayLoadDLLs)</DelayLoadDLLs>

--- a/win32/wconfig.cpp
+++ b/win32/wconfig.cpp
@@ -887,7 +887,11 @@ void WinRegisterConfigItems()
 	AddBoolC("DisplayFrameCount", Settings.DisplayMovieFrame, true, "true to show the frame count when a movie is playing");
 #undef CATEGORY
 #define CATEGORY "Display\\Win"
+#if DIRECTDRAW_DEFINED
 	AddUIntC("OutputMethod", GUI.outputMethod, 1, "0=DirectDraw, 1=Direct3D, 2=OpenGL");
+#else
+    AddUIntC("OutputMethod", GUI.outputMethod, 1, "0=Direct3D, 1=OpenGL");
+#endif
 	AddUIntC("FilterType", GUI.Scale, 0, filterString);
 	AddUIntC("FilterHiRes", GUI.ScaleHiRes, 0, filterString2);
 	AddBoolC("BlendHiRes", GUI.BlendHiRes, true, "true to horizontally blend Hi-Res images (better transparency effect on filters that do not account for this)");
@@ -906,7 +910,9 @@ void WinRegisterConfigItems()
 	AddBoolC("Stretch:MaintainAspectRatio", GUI.AspectRatio, true, "prevents stretching from changing the aspect ratio");
 	AddUIntC("Stretch:AspectRatioBaseWidth", GUI.AspectWidth, 256, "base width for aspect ratio calculation (AR=AspectRatioBaseWidth/224), default is 256 - set to 299 for 4:3 aspect ratio");
 	AddBoolC("Stretch:BilinearFilter", GUI.BilinearFilter, true, "allows bilinear filtering of stretching. Depending on your video card and the window size, this may result in a lower framerate.");
+#if DIRECTDRAW_DEFINED
 	AddBoolC("Stretch:LocalVidMem", GUI.LocalVidMem, true, "determines the location of video memory in DirectDraw mode. May increase or decrease rendering performance, depending on your setup and which filter and stretching options are active.");
+#endif
 	AddBool("Fullscreen:Enabled", GUI.FullScreen, false);
 	AddUInt("Fullscreen:Width", GUI.FullscreenMode.width, 640);
 	AddUInt("Fullscreen:Height", GUI.FullscreenMode.height, 480);

--- a/win32/win32_display.cpp
+++ b/win32/win32_display.cpp
@@ -198,7 +198,9 @@
 #include "wsnes9x.h"
 #include "win32_display.h"
 #include "CDirect3D.h"
+#if DIRECTDRAW_DEFINED
 #include "CDirectDraw.h"
+#endif
 #include "COpenGL.h"
 #include "IS9xDisplayOutput.h"
 
@@ -207,7 +209,9 @@
 
 // available display output methods
 CDirect3D Direct3D;
+#if DIRECTDRAW_DEFINED
 CDirectDraw DirectDraw;
+#endif
 COpenGL OpenGL;
 SSurface Src = {0};
 extern BYTE *ScreenBufferBlend;
@@ -258,9 +262,11 @@ bool WinDisplayReset(void)
 		case DIRECT3D:
 			S9xDisplayOutput = &Direct3D;
 			break;
+#if DIRECTDRAW_DEFINED
 		case DIRECTDRAW:
 			S9xDisplayOutput = &DirectDraw;
 			break;
+#endif
 		case OPENGL:
 			S9xDisplayOutput = &OpenGL;
 			break;
@@ -473,9 +479,9 @@ void ReduceToPath(TCHAR *filename)
 // TODO: abstract the following functions in some way - only necessary for directdraw
 
 /* DirectDraw only begin */
-
 void SwitchToGDI()
 {
+#if DIRECTDRAW_DEFINED
 	if(GUI.outputMethod!=DIRECTDRAW)
 		return;
 
@@ -483,10 +489,12 @@ void SwitchToGDI()
     DirectDraw.lpDD->FlipToGDISurface();
     GUI.FlipCounter = 0;
     DirectDraw.lpDDSPrimary2->SetPalette (NULL);
+#endif
 }
 
 static void ClearSurface (LPDIRECTDRAWSURFACE2 lpDDSurface)
 {
+#if DIRECTDRAW_DEFINED
     DDBLTFX fx;
 
     memset (&fx, 0, sizeof (fx));
@@ -494,11 +502,12 @@ static void ClearSurface (LPDIRECTDRAWSURFACE2 lpDDSurface)
 
     while (lpDDSurface->Blt (NULL, DirectDraw.lpDDSPrimary2, NULL, DDBLT_WAIT, NULL) == DDERR_SURFACELOST)
         lpDDSurface->Restore ();
+#endif
 }
 
 void UpdateBackBuffer()
 {
-
+#if DIRECTDRAW_DEFINED
     if (GUI.outputMethod==DIRECTDRAW && GUI.FullScreen)
     {
         SwitchToGDI();
@@ -536,10 +545,12 @@ void UpdateBackBuffer()
         if (GetMenu( GUI.hWnd) != NULL)
             DrawMenuBar (GUI.hWnd);
     }
+#endif
 }
 
 void RestoreGUIDisplay ()
 {
+#if DIRECTDRAW_DEFINED
 	if(GUI.outputMethod!=DIRECTDRAW)
 		return;
 
@@ -555,10 +566,12 @@ void RestoreGUIDisplay ()
     }
     SwitchToGDI();
     S9xClearPause (PAUSE_RESTORE_GUI);
+#endif
 }
 
 void RestoreSNESDisplay ()
 {
+#if DIRECTDRAW_DEFINED
 	if(GUI.outputMethod!=DIRECTDRAW)
 		return;
 
@@ -569,6 +582,7 @@ void RestoreSNESDisplay ()
     }
 
     UpdateBackBuffer();
+#endif
 }
 
 /* DirectDraw only end */

--- a/win32/wsnes9x.cpp
+++ b/win32/wsnes9x.cpp
@@ -609,7 +609,9 @@ static uint32 FrameTimings[] = {
 struct sLanguages Languages[] = {
 	{ IDR_MENU_US,
 		TEXT("Failed to initialize currently selected display output!\n Try switching to a different output method in the display settings."),
+#if DIRECTDRAW_DEFINED
 		TEXT("DirectDraw failed to set the selected display mode!"),
+#endif
 		TEXT("DirectSound failed to initialize; no sound will be played."),
 		TEXT("These settings won't take effect until you restart the emulator."),
 		TEXT("The frame timer failed to initialize, please do NOT select the automatic framerate option or Snes9X will crash!")}
@@ -1386,7 +1388,11 @@ int HandleKeyMessage(WPARAM wParam, LPARAM lParam)
 	switch (wParam)
 	{
 		case VK_ESCAPE:
-			if(GUI.outputMethod!=DIRECTDRAW && GUI.FullScreen && !GUI.EmulateFullscreen)
+			if(
+#if DIRECTDRAW_DEFINED
+                GUI.outputMethod!=DIRECTDRAW && 
+#endif
+                GUI.FullScreen && !GUI.EmulateFullscreen)
 				ToggleFullScreen();
 			else
 				if (GetMenu (GUI.hWnd) == NULL)
@@ -7327,7 +7333,9 @@ INT_PTR CALLBACK DlgFunky(HWND hDlg, UINT msg, WPARAM wParam, LPARAM lParam)
 
 		EnableWindow(GetDlgItem(hDlg, IDC_ASPECT), GUI.Stretch);
 
+#if DIRECTDRAW_DEFINED
 		SendDlgItemMessage(hDlg,IDC_OUTPUTMETHOD,CB_ADDSTRING,0,(LPARAM)TEXT("DirectDraw"));
+#endif
 		SendDlgItemMessage(hDlg,IDC_OUTPUTMETHOD,CB_ADDSTRING,0,(LPARAM)TEXT("Direct3D"));
 		SendDlgItemMessage(hDlg,IDC_OUTPUTMETHOD,CB_ADDSTRING,0,(LPARAM)TEXT("OpenGL"));
 		SendDlgItemMessage(hDlg,IDC_OUTPUTMETHOD,CB_SETCURSEL,(WPARAM)GUI.outputMethod,0);

--- a/win32/wsnes9x.h
+++ b/win32/wsnes9x.h
@@ -287,8 +287,12 @@ enum RenderFilter{
 };
 
 enum OutputMethod {
+#if DIRECTDRAW_DEFINED
 	DIRECTDRAW = 0,
 	DIRECT3D,
+#else
+    DIRECT3D = 0,
+#endif
 	OPENGL
 };
 
@@ -330,7 +334,9 @@ struct sGUI {
 	bool EmulateFullscreen;
 	bool EmulatedFullscreen;
 	bool BilinearFilter;
+#if DIRECTDRAW_DEFINED
 	bool LocalVidMem;
+#endif
 	bool Vsync;	
 	bool shaderEnabled;
 	TCHAR D3DshaderFileName[MAX_PATH];
@@ -434,7 +440,9 @@ struct sGUI {
 struct sLanguages {
     int idMenu;
     TCHAR *errInitDD;
+#if DIRECTDRAW_DEFINED
     TCHAR *errModeDD;
+#endif
     TCHAR *errInitDS;
     TCHAR *ApplyNeedRestart;
     TCHAR *errFrameTimer;


### PR DESCRIPTION
This puts all Directdraw-related code into a compile-time switch
'DIRECTDRAW_DEFINED'. To enable DirectDraw, you need to define this in
the snes9xw project file, and add a reference to drraw.lib in it too.

I still kept some DirectDraw-only functions (like SwitchToGDI() and RestoreSNESDisplay()) since there were ambitions of abstracting these functions.

If you merge this, then close #183.