### PR TITLE
GTK: Add a 10th save slot (Slot 9).

### DIFF
--- a/gtk/src/gtk_control.cpp
+++ b/gtk/src/gtk_control.cpp
@@ -65,6 +65,7 @@ const BindingLink b_links[] =
         { "b_save_6",              "QuickSave006"      },
         { "b_save_7",              "QuickSave007"      },
         { "b_save_8",              "QuickSave008"      },
+        { "b_save_9",              "QuickSave009"      },
         { "b_load_0",              "QuickLoad000"      },
         { "b_load_1",              "QuickLoad001"      },
         { "b_load_2",              "QuickLoad002"      },
@@ -74,6 +75,7 @@ const BindingLink b_links[] =
         { "b_load_6",              "QuickLoad006"      },
         { "b_load_7",              "QuickLoad007"      },
         { "b_load_8",              "QuickLoad008"      },
+        { "b_load_9",              "QuickLoad009"      },
         { "b_sound_channel_0",     "SoundChannel0"     },
         { "b_sound_channel_1",     "SoundChannel1"     },
         { "b_sound_channel_2",     "SoundChannel2"     },
@@ -101,9 +103,9 @@ const int b_breaks[] =
         24, /* End of turbo/sticky buttons */
         35, /* End of base emulator buttons */
         43, /* End of Graphic options */
-        61, /* End of save/load states */
-        70, /* End of sound buttons */
-        77, /* End of miscellaneous buttons */
+        63, /* End of save/load states */
+        72, /* End of sound buttons */
+        79, /* End of miscellaneous buttons */
         -1
 };
 

--- a/gtk/src/gtk_control.h
+++ b/gtk/src/gtk_control.h
@@ -38,7 +38,7 @@ typedef struct BindingLink
 extern const BindingLink b_links[];
 extern const int b_breaks[];
 #define NUM_JOYPAD_LINKS 24
-#define NUM_EMU_LINKS    53
+#define NUM_EMU_LINKS    55
 
 typedef struct JoypadBinding
 {

--- a/gtk/src/gtk_s9xwindow.cpp
+++ b/gtk/src/gtk_s9xwindow.cpp
@@ -1009,6 +1009,7 @@ Snes9xWindow::load_state_dialog ()
     gtk_file_filter_add_pattern (filter, "*.006");
     gtk_file_filter_add_pattern (filter, "*.007");
     gtk_file_filter_add_pattern (filter, "*.008");
+    gtk_file_filter_add_pattern (filter, "*.009");
     gtk_file_chooser_add_filter (GTK_FILE_CHOOSER (dialog), filter);
 
     filter = gtk_file_filter_new ();
@@ -1132,6 +1133,7 @@ Snes9xWindow::save_state_dialog ()
     gtk_file_filter_add_pattern (filter, "*.006");
     gtk_file_filter_add_pattern (filter, "*.007");
     gtk_file_filter_add_pattern (filter, "*.008");
+    gtk_file_filter_add_pattern (filter, "*.009");
     gtk_file_chooser_add_filter (GTK_FILE_CHOOSER (dialog), filter);
 
     filter = gtk_file_filter_new ();
@@ -1907,6 +1909,7 @@ Snes9xWindow::update_accels (void)
     set_menu_item_accel_to_binding ("save_state_6", "QuickSave006");
     set_menu_item_accel_to_binding ("save_state_7", "QuickSave007");
     set_menu_item_accel_to_binding ("save_state_8", "QuickSave008");
+    set_menu_item_accel_to_binding ("save_state_9", "QuickSave009");
     set_menu_item_accel_to_binding ("load_state_0", "QuickLoad000");
     set_menu_item_accel_to_binding ("load_state_1", "QuickLoad001");
     set_menu_item_accel_to_binding ("load_state_2", "QuickLoad002");
@@ -1916,6 +1919,7 @@ Snes9xWindow::update_accels (void)
     set_menu_item_accel_to_binding ("load_state_6", "QuickLoad006");
     set_menu_item_accel_to_binding ("load_state_7", "QuickLoad007");
     set_menu_item_accel_to_binding ("load_state_8", "QuickLoad008");
+    set_menu_item_accel_to_binding ("load_state_9", "QuickLoad009");
     set_menu_item_accel_to_binding ("pause_item", "GTK_pause");
     set_menu_item_accel_to_binding ("save_spc_item", "GTK_save_spc");
     set_menu_item_accel_to_binding ("open_rom_item", "GTK_open_rom");

--- a/gtk/src/snes9x.ui
+++ b/gtk/src/snes9x.ui
@@ -1199,6 +1199,15 @@
                               </object>
                             </child>
                             <child>
+                              <object class="GtkMenuItem" id="load_state_9">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label" translatable="yes">Slot _9</property>
+                                <property name="use_underline">True</property>
+                                <signal name="activate" handler="load_save_state" swapped="no"/>
+                              </object>
+                            </child>
+                            <child>
                               <object class="GtkSeparatorMenuItem" id="separator7">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
@@ -1304,6 +1313,15 @@
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="label" translatable="yes">Slot _8</property>
+                                <property name="use_underline">True</property>
+                                <signal name="activate" handler="save_save_state" swapped="no"/>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkMenuItem" id="save_state_9">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label" translatable="yes">Slot _9</property>
                                 <property name="use_underline">True</property>
                                 <signal name="activate" handler="save_save_state" swapped="no"/>
                               </object>
@@ -7144,7 +7162,7 @@
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="border_width">10</property>
-                                    <property name="n_rows">10</property>
+                                    <property name="n_rows">11</property>
                                     <property name="n_columns">4</property>
                                     <property name="column_spacing">10</property>
                                     <property name="row_spacing">5</property>
@@ -7179,20 +7197,6 @@
                                       </packing>
                                     </child>
                                     <child>
-                                      <object class="GtkLabel" id="label75">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="xalign">0</property>
-                                        <property name="label" translatable="yes">Slot 1</property>
-                                      </object>
-                                      <packing>
-                                        <property name="top_attach">2</property>
-                                        <property name="bottom_attach">3</property>
-                                        <property name="x_options"/>
-                                        <property name="y_options"/>
-                                      </packing>
-                                    </child>
-                                    <child>
                                       <object class="GtkLabel" id="label74">
                                         <property name="visible">True</property>
                                         <property name="can_focus">False</property>
@@ -7202,6 +7206,20 @@
                                       <packing>
                                         <property name="top_attach">1</property>
                                         <property name="bottom_attach">2</property>
+                                        <property name="x_options"/>
+                                        <property name="y_options"/>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel" id="label75">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="xalign">0</property>
+                                        <property name="label" translatable="yes">Slot 1</property>
+                                      </object>
+                                      <packing>
+                                        <property name="top_attach">2</property>
+                                        <property name="bottom_attach">3</property>
                                         <property name="x_options"/>
                                         <property name="y_options"/>
                                       </packing>
@@ -7286,6 +7304,34 @@
                                       <packing>
                                         <property name="top_attach">8</property>
                                         <property name="bottom_attach">9</property>
+                                        <property name="x_options"/>
+                                        <property name="y_options"/>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel" id="label102">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="xalign">0</property>
+                                        <property name="label" translatable="yes">Slot 8</property>
+                                      </object>
+                                      <packing>
+                                        <property name="top_attach">9</property>
+                                        <property name="bottom_attach">10</property>
+                                        <property name="x_options"/>
+                                        <property name="y_options"/>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel" id="label152">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="xalign">0</property>
+                                        <property name="label" translatable="yes">Slot 9</property>
+                                      </object>
+                                      <packing>
+                                        <property name="top_attach">10</property>
+                                        <property name="bottom_attach">11</property>
                                         <property name="x_options"/>
                                         <property name="y_options"/>
                                       </packing>
@@ -7435,15 +7481,17 @@
                                       </packing>
                                     </child>
                                     <child>
-                                      <object class="GtkLabel" id="label102">
+                                      <object class="GtkLabel" id="label158">
                                         <property name="visible">True</property>
                                         <property name="can_focus">False</property>
                                         <property name="xalign">0</property>
-                                        <property name="label" translatable="yes">Slot 8</property>
+                                        <property name="label" translatable="yes">Slot 9</property>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">9</property>
-                                        <property name="bottom_attach">10</property>
+                                        <property name="left_attach">2</property>
+                                        <property name="right_attach">3</property>
+                                        <property name="top_attach">10</property>
+                                        <property name="bottom_attach">11</property>
                                         <property name="x_options"/>
                                         <property name="y_options"/>
                                       </packing>
@@ -7620,6 +7668,25 @@
                                       </packing>
                                     </child>
                                     <child>
+                                      <object class="GtkEntry" id="b_save_9">
+                                        <property name="width_request">50</property>
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="editable">False</property>
+                                        <property name="primary_icon_activatable">False</property>
+                                        <property name="secondary_icon_activatable">False</property>
+                                        <property name="primary_icon_sensitive">True</property>
+                                        <property name="secondary_icon_sensitive">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left_attach">1</property>
+                                        <property name="right_attach">2</property>
+                                        <property name="top_attach">10</property>
+                                        <property name="bottom_attach">11</property>
+                                        <property name="y_options">GTK_FILL</property>
+                                      </packing>
+                                    </child>
+                                    <child>
                                       <object class="GtkEntry" id="b_load_0">
                                         <property name="width_request">50</property>
                                         <property name="visible">True</property>
@@ -7639,25 +7706,6 @@
                                       </packing>
                                     </child>
                                     <child>
-                                      <object class="GtkEntry" id="b_load_2">
-                                        <property name="width_request">50</property>
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="editable">False</property>
-                                        <property name="primary_icon_activatable">False</property>
-                                        <property name="secondary_icon_activatable">False</property>
-                                        <property name="primary_icon_sensitive">True</property>
-                                        <property name="secondary_icon_sensitive">True</property>
-                                      </object>
-                                      <packing>
-                                        <property name="left_attach">3</property>
-                                        <property name="right_attach">4</property>
-                                        <property name="top_attach">3</property>
-                                        <property name="bottom_attach">4</property>
-                                        <property name="y_options">GTK_FILL</property>
-                                      </packing>
-                                    </child>
-                                    <child>
                                       <object class="GtkEntry" id="b_load_1">
                                         <property name="width_request">50</property>
                                         <property name="visible">True</property>
@@ -7673,6 +7721,25 @@
                                         <property name="right_attach">4</property>
                                         <property name="top_attach">2</property>
                                         <property name="bottom_attach">3</property>
+                                        <property name="y_options">GTK_FILL</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkEntry" id="b_load_2">
+                                        <property name="width_request">50</property>
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="editable">False</property>
+                                        <property name="primary_icon_activatable">False</property>
+                                        <property name="secondary_icon_activatable">False</property>
+                                        <property name="primary_icon_sensitive">True</property>
+                                        <property name="secondary_icon_sensitive">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left_attach">3</property>
+                                        <property name="right_attach">4</property>
+                                        <property name="top_attach">3</property>
+                                        <property name="bottom_attach">4</property>
                                         <property name="y_options">GTK_FILL</property>
                                       </packing>
                                     </child>
@@ -7715,7 +7782,7 @@
                                       </packing>
                                     </child>
                                     <child>
-                                      <object class="GtkEntry" id="b_load_8">
+                                      <object class="GtkEntry" id="b_load_5">
                                         <property name="width_request">50</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
@@ -7728,8 +7795,8 @@
                                       <packing>
                                         <property name="left_attach">3</property>
                                         <property name="right_attach">4</property>
-                                        <property name="top_attach">9</property>
-                                        <property name="bottom_attach">10</property>
+                                        <property name="top_attach">6</property>
+                                        <property name="bottom_attach">7</property>
                                         <property name="y_options">GTK_FILL</property>
                                       </packing>
                                     </child>
@@ -7753,25 +7820,6 @@
                                       </packing>
                                     </child>
                                     <child>
-                                      <object class="GtkEntry" id="b_load_5">
-                                        <property name="width_request">50</property>
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="editable">False</property>
-                                        <property name="primary_icon_activatable">False</property>
-                                        <property name="secondary_icon_activatable">False</property>
-                                        <property name="primary_icon_sensitive">True</property>
-                                        <property name="secondary_icon_sensitive">True</property>
-                                      </object>
-                                      <packing>
-                                        <property name="left_attach">3</property>
-                                        <property name="right_attach">4</property>
-                                        <property name="top_attach">6</property>
-                                        <property name="bottom_attach">7</property>
-                                        <property name="y_options">GTK_FILL</property>
-                                      </packing>
-                                    </child>
-                                    <child>
                                       <object class="GtkEntry" id="b_load_7">
                                         <property name="width_request">50</property>
                                         <property name="visible">True</property>
@@ -7787,6 +7835,44 @@
                                         <property name="right_attach">4</property>
                                         <property name="top_attach">8</property>
                                         <property name="bottom_attach">9</property>
+                                        <property name="y_options">GTK_FILL</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkEntry" id="b_load_8">
+                                        <property name="width_request">50</property>
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="editable">False</property>
+                                        <property name="primary_icon_activatable">False</property>
+                                        <property name="secondary_icon_activatable">False</property>
+                                        <property name="primary_icon_sensitive">True</property>
+                                        <property name="secondary_icon_sensitive">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left_attach">3</property>
+                                        <property name="right_attach">4</property>
+                                        <property name="top_attach">9</property>
+                                        <property name="bottom_attach">10</property>
+                                        <property name="y_options">GTK_FILL</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkEntry" id="b_load_9">
+                                        <property name="width_request">50</property>
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="editable">False</property>
+                                        <property name="primary_icon_activatable">False</property>
+                                        <property name="secondary_icon_activatable">False</property>
+                                        <property name="primary_icon_sensitive">True</property>
+                                        <property name="secondary_icon_sensitive">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left_attach">3</property>
+                                        <property name="right_attach">4</property>
+                                        <property name="top_attach">10</property>
+                                        <property name="bottom_attach">11</property>
                                         <property name="y_options">GTK_FILL</property>
                                       </packing>
                                     </child>


### PR DESCRIPTION
... Reorganizing save slots section of snes9x.ui while I'm at it.

I was annoyed at snes9x-gtk having save slots only up to 8 when other emus and even windows port have save slots up to 9.

This pull request is a step towards feature parity.