### PR TITLE
Move away from deprecated functions in the GTK port

### DIFF
--- a/gtk/src/gtk_netplay.cpp
+++ b/gtk/src/gtk_netplay.cpp
@@ -149,10 +149,7 @@ S9xNetplayStartServer (void)
     NPServer.SyncByReset = gui_config->netplay_sync_reset;
     NPServer.SendROMImageOnConnect = gui_config->netplay_send_rom;
 
-    npthread = g_thread_create (S9xNetplayServerThread,
-                                NULL,
-                                TRUE,
-                                NULL);
+    npthread = g_thread_new (NULL, S9xNetplayServerThread, NULL);
 
     /* Sleep to let the server create itself */
     usleep (10000);

--- a/gtk/src/gtk_s9x.cpp
+++ b/gtk/src/gtk_s9x.cpp
@@ -45,7 +45,6 @@ main (int argc, char *argv[])
 {
     struct sigaction sig_callback;
 
-    g_thread_init (NULL);
     gdk_threads_init ();
     gdk_threads_enter ();
 

--- a/gtk/src/gtk_s9xwindow.cpp
+++ b/gtk/src/gtk_s9xwindow.cpp
@@ -607,8 +607,14 @@ Snes9xWindow::Snes9xWindow (Snes9xConfig *config) :
     }
     else
     {
-        icon = gdk_pixbuf_new_from_inline (-1, app_icon, FALSE, NULL);
-        gtk_window_set_default_icon (icon);
+        GdkPixbufLoader *loader = gdk_pixbuf_loader_new ();
+        if (gdk_pixbuf_loader_write (loader, (const guchar *)app_icon, sizeof (app_icon), NULL) &&
+            gdk_pixbuf_loader_close (loader, NULL) &&
+            (icon = gdk_pixbuf_loader_get_pixbuf (loader)))
+        {
+            gtk_window_set_default_icon (icon);
+        }
+        g_object_unref(loader);
     }
 
     drawing_area = GTK_DRAWING_AREA (get_widget ("drawingarea"));


### PR DESCRIPTION
Looking at the build warnings, there were two uses of deprecated GTK/GDK functions. These looked easy to replace with non-deprecated ones, so I did so.