### PR TITLE
Modify src/gtk/snes9x.ui to add scroll-box to gtk2+ cheat dialog.

### DIFF
--- a/gtk/src/snes9x.ui
+++ b/gtk/src/snes9x.ui
@@ -305,10 +305,19 @@
                 <property name="label_xalign">0</property>
                 <property name="shadow_type">in</property>
                 <child>
-                  <object class="GtkTreeView" id="cheat_treeview">
+                  <object class="GtkScrolledWindow" id="scrolledwindow9">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can_focus">True</property>
                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+                    <property name="hscrollbar_policy">never</property>
+                    <property name="vscrollbar_policy">automatic</property>
+                    <child>
+                      <object class="GtkTreeView" id="cheat_treeview">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+                      </object>
+                    </child>
                   </object>
                 </child>
                 <child type="label_item">


### PR DESCRIPTION
Reference issue "Linux gtk+ cheat window has no scroll-bar #255".  Proposed change to file as shown to add gtk2+ scroll box.

I have tested this change and it seems to work.  The rewrite was made based on code formatting and structures already present in file snes9x.ui.  I simply copied a relevant portion and pasted it to the appropriate spot while maintaining existing formatting.  Would be grateful of an experienced coder/dev's review.