### PR TITLE
unix: fix fullscreen property change timing

### DIFF
--- a/unix/x11.cpp
+++ b/unix/x11.cpp
@@ -862,6 +862,12 @@ void S9xInitDisplay (int argc, char **argv)
 							WidthOfScreen(GUI.screen), HeightOfScreen(GUI.screen), 0,
 							GUI.depth, InputOutput, GUI.visual, CWBackPixel | CWColormap, &attrib);
 
+		/* Try to tell the Window Manager not to decorate this window. */
+		Atom wm_state   = XInternAtom (GUI.display, "_NET_WM_STATE", true );
+		Atom wm_fullscreen = XInternAtom (GUI.display, "_NET_WM_STATE_FULLSCREEN", true );
+
+		XChangeProperty(GUI.display, GUI.window, wm_state, XA_ATOM, 32, PropModeReplace, (unsigned char *)&wm_fullscreen, 1);
+
 #ifdef USE_XVIDEO
 		if (GUI.use_xvideo)
 		{
@@ -963,15 +969,6 @@ void S9xInitDisplay (int argc, char **argv)
 	do {
 		XNextEvent(GUI.display, &event);
 	} while (event.type != MapNotify || event.xmap.event != GUI.window);
-
-	if (GUI.fullscreen)
-	{
-		/* Try to tell the Window Manager not to decorate this window. */
-		Atom wm_state   = XInternAtom (GUI.display, "_NET_WM_STATE", true );
-		Atom wm_fullscreen = XInternAtom (GUI.display, "_NET_WM_STATE_FULLSCREEN", true );
-
-		XChangeProperty(GUI.display, GUI.window, wm_state, XA_ATOM, 32, PropModeReplace, (unsigned char *)&wm_fullscreen, 1);
-	}
 
 #ifdef USE_XVIDEO
 	if (GUI.use_xvideo)


### PR DESCRIPTION
Previously, the Unix version of Snes9x was unable to create a fullscreen window.  (It would create a regular window the size of the screen.)