### PR TITLE
AppVeyor support (CI service for Windows)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,45 @@
+version: 1.55-{build}
+
+image: Visual Studio 2017
+
+environment:
+  matrix:
+  - generator: "Visual Studio 15"
+    config: Release Unicode
+    platform: Win32
+    arch: win32
+    output: win32\snes9x.exe
+    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+
+  - generator: "Visual Studio 15"
+    config: Release Unicode
+    platform: x64
+    arch: win32-x64
+    output: win32\snes9x-x64.exe
+    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+
+init:
+  - git config --global core.autocrlf input
+
+before_build:
+  - git submodule update --init --recursive
+
+build_script:
+  - msbuild win32\snes9xw.sln /t:build /p:Configuration="%config%";Platform="%platform%" /m /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+
+after_build:
+  - ps: $env:gitrev = git describe --tags
+  - ps: $env:my_version = "$env:gitrev"
+  - set package_name=snes9x-%my_version%-%arch%
+  - if exist artifacts rmdir /s /q artifacts
+  - mkdir artifacts
+  - copy "%output%" artifacts
+  - copy docs\changes.txt artifacts
+  - copy docs\snes9x-license.txt artifacts
+  - copy win32\docs\faqs-windows.txt artifacts
+  - copy win32\docs\readme-windows.txt artifacts
+  - 7z a %package_name%.zip .\artifacts\*
+
+artifacts:
+  - path: $(package_name).zip
+    name: $(arch)


### PR DESCRIPTION
This update adds the configuration file of [AppVeyor](https://www.appveyor.com/), a Continuous Integration and Deployment service for Windows.

Advantages consist of:
* ability of auto build. You can know whether a PR will break Windows build, even if you're not using Windows.
* ability of auto packaging. The generated binary can be downloaded as a zip file.
* build status badge. You can indicate the build status in README or website if you want.

[AppVeyor build result example](https://ci.appveyor.com/project/gocha/snes9x/build/1.55-5)

**To active member using Windows**: if you would accept this PR, could you make a project for snes9xgit repository to your appveyor account?
