### PR TITLE
[BS-X] Fix Block Allocation Flags when needed

### DIFF
--- a/bsx.cpp
+++ b/bsx.cpp
@@ -1477,6 +1477,12 @@ void S9xInitBSX (void)
 			FlashMode = (header[0x18] & 0xEF) == 0x20 ? FALSE : TRUE;
 			FlashSize = FLASH_SIZE;
 
+			// Fix Block Allocation Flags
+			// (for games that don't have it setup properly,
+			// for exemple when taken seperately from the upper memory of the Memory Pack,
+			// else the game will error out on BS-X)
+			for (; (header[0x10] & 1) == 0; (header[0x10] >>= 1));
+
 #ifdef BSX_DEBUG
 			for (int i = 0; i <= 0x1F; i++)
 				printf("BS: ROM Header %02X: %02X\n", i, header[i]);


### PR DESCRIPTION
This change is more of a quality of life thing.

To explain what's going on, sometimes some of the Memory Pack dumps going around are taken from the upper part of its memory. As such, the Block Allocation Flags (At Header + 0x10) will then tell the BS-X to do a checksum of the blocks indicated but since the file is cleaned up, the data itself is loaded to lower memory, making the checksum fail as a result.

This change only shifts the allocation bits to the start of Memory Pack data during BS emulation initialization when a Memory Pack is loaded. This part of the data is not checksummed.

Unfortunately it's not very easy to fix ROMs that are already out there for such a long time, I'll always have someone who will complain that Kirby's Toy Box - Pinball will not work for this very reason.