### PR TITLE
[BS-X] Preventing infinite loop when fixing Allocation flags

### DIFF
--- a/bsx.cpp
+++ b/bsx.cpp
@@ -1481,7 +1481,7 @@ void S9xInitBSX (void)
 			// (for games that don't have it setup properly,
 			// for exemple when taken seperately from the upper memory of the Memory Pack,
 			// else the game will error out on BS-X)
-			for (; (header[0x10] & 1) == 0; (header[0x10] >>= 1));
+			for (; (((header[0x10] & 1) == 0) && header[0x10] != 0); (header[0x10] >>= 1));
 
 #ifdef BSX_DEBUG
 			for (int i = 0; i <= 0x1F; i++)


### PR DESCRIPTION
Huge bug fix. Tested. I'm dumb sometimes.

(I doubt anyone would be able to trigger it under normal circumstances, but better safe than sorry.)