### PR TITLE
WIP: Wayland support

### DIFF
--- a/gtk/src/gtk_config.cpp
+++ b/gtk/src/gtk_config.cpp
@@ -5,7 +5,9 @@
 #include <libxml/parser.h>
 #include <libxml/tree.h>
 #include <libxml/xmlwriter.h>
+#ifdef GDK_WINDOWING_X11
 #include <gdk/gdkx.h>
+#endif
 #include <gtk/gtk.h>
 #include <gdk/gdk.h>
 #include <gdk/gdkkeysyms.h>

--- a/gtk/src/gtk_display.cpp
+++ b/gtk/src/gtk_display.cpp
@@ -1,5 +1,7 @@
 #include <gdk/gdk.h>
+#ifdef GDK_WINDOWING_X11
 #include <gdk/gdkx.h>
+#endif
 #include <sched.h>
 
 #include "gtk_s9x.h"

--- a/gtk/src/gtk_display.cpp
+++ b/gtk/src/gtk_display.cpp
@@ -10,10 +10,14 @@
 #include "gtk_display_driver_gtk.h"
 #include "snes_ntsc.h"
 #ifdef USE_XV
+#ifdef GDK_WINDOWING_X11
 #include "gtk_display_driver_xv.h"
 #endif
+#endif
 #ifdef USE_OPENGL
+#ifdef GDK_WINDOWING_X11
 #include "gtk_display_driver_opengl.h"
+#endif
 #endif
 
 static S9xDisplayDriver  *driver;
@@ -1561,23 +1565,27 @@ S9xDisplayReconfigure (void)
 void
 S9xQueryDrivers (void)
 {
-#ifdef USE_XV
-    gui_config->allow_xv = S9xXVDisplayDriver::query_availability ();
-#else
+
     gui_config->allow_xv = 0;
+
+#ifdef USE_XV
+#ifdef GDK_WINDOWING_X11
+    gui_config->allow_xv = S9xXVDisplayDriver::query_availability ();
+#endif
 #endif
 
-#ifdef USE_OPENGL
-    gui_config->allow_opengl = S9xOpenGLDisplayDriver::query_availability ();
-#else
     gui_config->allow_opengl = 0;
+
+#ifdef USE_OPENGL
+#ifdef GDK_WINDOWING_X11
+    gui_config->allow_opengl = S9xOpenGLDisplayDriver::query_availability ();
+#endif
 #endif
 
     gui_config->allow_xrandr = 0;
     
 #ifdef GDK_WINDOWING_X11
-    GdkDisplay *display = gtk_widget_get_display (GTK_WIDGET (top_level->get_window()));
-    if (GDK_IS_X11_DISPLAY (display))
+    if (GDK_IS_X11_DISPLAY (gdk_display_get_default ()))
     {
         int error_base_p, event_base_p;
         int major_version, minor_version;
@@ -1684,6 +1692,7 @@ S9xInitDriver (void)
     switch (gui_config->hw_accel)
     {
 #ifdef USE_OPENGL
+#ifdef GDK_WINDOWING_X11
         case HWA_OPENGL:
 
             driver = new S9xOpenGLDisplayDriver (top_level,
@@ -1691,12 +1700,15 @@ S9xInitDriver (void)
 
             break;
 #endif
+#endif
 #ifdef USE_XV
+#ifdef GDK_WINDOWING_X11
         case HWA_XV:
 
             driver = new S9xXVDisplayDriver (top_level, gui_config);
 
             break;
+#endif
 #endif
         default:
 

--- a/gtk/src/gtk_display.cpp
+++ b/gtk/src/gtk_display.cpp
@@ -1596,7 +1596,13 @@ S9xQueryDrivers (void)
 }
 
 bool8
-S9xDeinitUpdate (int width, int height)
+S9xDeinitUpdate (int width, int height) {
+    gdk_window_invalidate_rect(gtk_widget_get_window (GTK_WIDGET (top_level->drawing_area)), NULL, gtk_false ());
+    return TRUE;
+}
+
+bool8
+S9xUpdateDisplay (int width, int height)
 {
     int yoffset = 0;
 

--- a/gtk/src/gtk_display.cpp
+++ b/gtk/src/gtk_display.cpp
@@ -1574,34 +1574,24 @@ S9xQueryDrivers (void)
 #endif
 
     gui_config->allow_xrandr = 0;
+    
+#ifdef GDK_WINDOWING_X11
+    GdkDisplay *display = gtk_widget_get_display (GTK_WIDGET (top_level->get_window()));
+    if (GDK_IS_X11_DISPLAY (display))
+    {
+        int error_base_p, event_base_p;
+        int major_version, minor_version;
+        Display *dpy = gdk_x11_display_get_xdisplay (gtk_widget_get_display (GTK_WIDGET (top_level->get_window())));
+        Window xid   = gdk_x11_window_get_xid (gtk_widget_get_window (GTK_WIDGET (top_level->get_window())));
 
-    int error_base_p, event_base_p;
-    int major_version, minor_version;
-    Display *dpy = gdk_x11_display_get_xdisplay (gtk_widget_get_display (GTK_WIDGET (top_level->get_window())));
-    Window xid   = GDK_COMPAT_WINDOW_XID (gtk_widget_get_window (GTK_WIDGET (top_level->get_window())));
-
-    if (!XRRQueryExtension (dpy, &event_base_p, &error_base_p))
-    {
-        gui_config->change_display_resolution = FALSE;
-        return;
-    }
-    if (!XRRQueryVersion (dpy, &major_version, &minor_version))
-    {
-        gui_config->change_display_resolution = FALSE;
-        return;
-    }
-    if (minor_version < 3)
-    {
-        gui_config->change_display_resolution = FALSE;
-        return;
+        gui_config->allow_xrandr = 1;
+        gui_config->xrr_screen_resources = XRRGetScreenResourcesCurrent (dpy, xid);
+        gui_config->xrr_crtc_info        = XRRGetCrtcInfo (dpy,
+                                                        gui_config->xrr_screen_resources,
+                                                        gui_config->xrr_screen_resources->crtcs[0]);
     }
 
-    gui_config->allow_xrandr = 1;
-    gui_config->xrr_screen_resources = XRRGetScreenResourcesCurrent (dpy, xid);
-    gui_config->xrr_crtc_info        = XRRGetCrtcInfo (dpy,
-                                                       gui_config->xrr_screen_resources,
-                                                       gui_config->xrr_screen_resources->crtcs[0]);
-
+#endif
     return;
 }
 

--- a/gtk/src/gtk_display.h
+++ b/gtk/src/gtk_display.h
@@ -111,6 +111,7 @@ void S9xDisplayClearBuffers (void);
 void S9xReinitDisplay (void);
 void S9xDisplayReconfigure (void);
 void S9xQueryDrivers (void);
+bool8 S9xUpdateDisplay (int width, int height);
 
 S9xDisplayDriver *S9xDisplayGetDriver (void);
 

--- a/gtk/src/gtk_display_driver_opengl.cpp
+++ b/gtk/src/gtk_display_driver_opengl.cpp
@@ -886,8 +886,14 @@ S9xOpenGLDisplayDriver::reconfigure (int width, int height)
 int
 S9xOpenGLDisplayDriver::query_availability (void)
 {
+    GdkDisplay *gdk_display = gdk_display_get_default ();
+    if (!GDK_IS_X11_DISPLAY (gdk_display))
+    {
+        return 0;
+    }
+
     int errorBase, eventBase;
-    Display *display = GDK_DISPLAY_XDISPLAY (gdk_display_get_default ());
+    Display *display = GDK_DISPLAY_XDISPLAY (gdk_display);
 
     if (glXQueryExtension (display, &errorBase, &eventBase) == False)
     {

--- a/gtk/src/gtk_display_driver_opengl.cpp
+++ b/gtk/src/gtk_display_driver_opengl.cpp
@@ -1,8 +1,10 @@
 #include <gtk/gtk.h>
-#include <gdk/gdkx.h>
 #include <libxml/parser.h>
 #include <libxml/tree.h>
+#ifdef GDK_WINDOWING_X11
+#include <gdk/gdkx.h>
 #include <X11/Xlib.h>
+#endif
 #include <dlfcn.h>
 #include <sys/stat.h>
 #include <fcntl.h>

--- a/gtk/src/gtk_display_driver_xv.cpp
+++ b/gtk/src/gtk_display_driver_xv.cpp
@@ -608,12 +608,18 @@ S9xXVDisplayDriver::clear_buffers (void)
 int
 S9xXVDisplayDriver::query_availability (void)
 {
+    GdkDisplay *gdk_display = gdk_display_get_default ();
+    if (!GDK_IS_X11_DISPLAY (gdk_display))
+    {
+        return 0;
+    }
+
     unsigned int p_version,
                  p_release,
                  p_request_base,
                  p_event_base,
                  p_error_base;
-    Display *display = GDK_DISPLAY_XDISPLAY (gdk_display_get_default ());
+    Display *display = GDK_DISPLAY_XDISPLAY (gdk_display);
 
     /* Test if XV and SHM are feasible */
     if (!XShmQueryExtension (display))

--- a/gtk/src/gtk_preferences.cpp
+++ b/gtk/src/gtk_preferences.cpp
@@ -1,7 +1,9 @@
 #include <string>
 #include <stdlib.h>
 #include <gdk/gdkkeysyms.h>
+#ifdef GDK_WINDOWING_X11
 #include <gdk/gdkx.h>
+#endif
 
 #include "gtk_preferences.h"
 #include "gtk_config.h"

--- a/gtk/src/gtk_s9x.cpp
+++ b/gtk/src/gtk_s9x.cpp
@@ -2,7 +2,9 @@
 #include <sys/time.h>
 #include <signal.h>
 #include <gdk/gdk.h>
+#ifdef GDK_WINDOWING_X11
 #include <gdk/gdkx.h>
+#endif
 
 #include "gtk_s9x.h"
 #include "gtk_control.h"

--- a/gtk/src/gtk_s9xwindow.cpp
+++ b/gtk/src/gtk_s9xwindow.cpp
@@ -1708,11 +1708,14 @@ Snes9xWindow::enter_fullscreen_mode (void)
 
     gdk_display_sync (gdk_display_get_default ());
     gtk_window_present (GTK_WINDOW (window));
-
-    set_bypass_compositor (gdk_x11_display_get_xdisplay (gtk_widget_get_display (GTK_WIDGET (window))),
-                           GDK_COMPAT_WINDOW_XID (gtk_widget_get_window (GTK_WIDGET (window))),
-                           1);
-
+#ifdef GDK_WINDOWING_X11
+    if (GDK_IS_X11_WINDOW (gtk_widget_get_window (GTK_WIDGET (window))))
+    {
+        set_bypass_compositor (gdk_x11_display_get_xdisplay (gtk_widget_get_display (GTK_WIDGET (window))),
+                               GDK_COMPAT_WINDOW_XID (gtk_widget_get_window (GTK_WIDGET (window))),
+                               1);
+    }
+#endif
     config->fullscreen = 1;
     config->rom_loaded = rom_loaded;
 
@@ -1764,9 +1767,14 @@ Snes9xWindow::leave_fullscreen_mode (void)
 
     gtk_window_unfullscreen (GTK_WINDOW (window));
 
-    set_bypass_compositor (gdk_x11_display_get_xdisplay (gtk_widget_get_display (GTK_WIDGET (window))),
-                           GDK_COMPAT_WINDOW_XID (gtk_widget_get_window (GTK_WIDGET (window))),
-                           0);
+#ifdef GDK_WINDOWING_X11
+    if (GDK_IS_X11_WINDOW (gtk_widget_get_window (GTK_WIDGET (window))))
+    {
+        set_bypass_compositor (gdk_x11_display_get_xdisplay (gtk_widget_get_display (GTK_WIDGET (window))),
+                               GDK_COMPAT_WINDOW_XID (gtk_widget_get_window (GTK_WIDGET (window))),
+                               0);
+    }
+#endif
 
     resize (nfs_width, nfs_height);
     gtk_window_move (GTK_WINDOW (window), nfs_x, nfs_y);

--- a/gtk/src/gtk_s9xwindow.cpp
+++ b/gtk/src/gtk_s9xwindow.cpp
@@ -1,5 +1,7 @@
 #include <gdk/gdk.h>
+#ifdef GDK_WINDOWING_X11
 #include <gdk/gdkx.h>
+#endif
 #include <gdk/gdkkeysyms.h>
 #include <cairo.h>
 #include <X11/Xatom.h>

--- a/gtk/src/gtk_s9xwindow.cpp
+++ b/gtk/src/gtk_s9xwindow.cpp
@@ -1546,7 +1546,18 @@ Snes9xWindow::reset_screensaver (void)
     if (!focused)
         return;
 
-    XResetScreenSaver (GDK_DISPLAY_XDISPLAY (gdk_display_get_default ()));
+#ifdef GDK_WINDOWING_X11
+    if (GDK_IS_X11_WINDOW (gtk_widget_get_window (GTK_WIDGET (window))))
+    {
+        XResetScreenSaver (GDK_DISPLAY_XDISPLAY (gdk_display_get_default ()));
+    }
+#endif
+#ifdef GDK_WINDOWING_WAYLAND
+    if (GDK_IS_WAYLAND_WINDOW (gtk_widget_get_window (GTK_WIDGET (window))))
+    {
+    // TODO screensaver for wayland
+    }
+#endif
 
     config->screensaver_needs_reset = FALSE;
 

--- a/gtk/src/gtk_s9xwindow.cpp
+++ b/gtk/src/gtk_s9xwindow.cpp
@@ -2,6 +2,9 @@
 #ifdef GDK_WINDOWING_X11
 #include <gdk/gdkx.h>
 #endif
+#ifdef GDK_WINDOWING_WAYLAND
+#include <gdk/gdkwayland.h>
+#endif
 #include <gdk/gdkkeysyms.h>
 #include <cairo.h>
 #include <X11/Xatom.h>
@@ -1606,10 +1609,24 @@ static double XRRGetExactRefreshRate (Display *dpy, Window window)
 double
 Snes9xWindow::get_refresh_rate (void)
 {
+    double refresh_rate = 0.0;
+    GdkDisplay *display = gtk_widget_get_display (window);
+    GdkWindow *gdk_window =  gtk_widget_get_window (window);
+#ifdef GDK_WINDOWING_X11
+    if (GDK_IS_X11_DISPLAY (display))
+    {
     Window xid = GDK_COMPAT_WINDOW_XID (gtk_widget_get_window (window));
     Display *dpy = gdk_x11_display_get_xdisplay (gtk_widget_get_display (window));
-    double refresh_rate = XRRGetExactRefreshRate (dpy, xid);
-
+    refresh_rate = XRRGetExactRefreshRate (dpy, xid);
+    } else
+#endif
+#ifdef GDK_WINDOWING_WAYLAND
+    if (GDK_IS_WAYLAND_DISPLAY (display))
+    {
+        GdkMonitor *monitor = gdk_display_get_monitor_at_window(display, gdk_window);
+        refresh_rate = (double) gdk_monitor_get_refresh_rate(monitor) / 1000.0;
+    }
+#endif
     if (refresh_rate < 10.0)
     {
         printf ("Warning: Couldn't read refresh rate.\n");

--- a/gtk/src/gtk_s9xwindow.cpp
+++ b/gtk/src/gtk_s9xwindow.cpp
@@ -755,14 +755,7 @@ Snes9xWindow::expose (void)
         config->window_height = get_height ();
     }
 
-    if (is_paused ()
-#ifdef NETPLAY_SUPPORT
-            || NetPlay.Paused
-#endif
-    )
-    {
-        S9xDeinitUpdate (last_width, last_height);
-    }
+    S9xUpdateDisplay (last_width, last_height);
 
     return;
 }


### PR DESCRIPTION
Hi!
As is said in #291, I have begun to make the gtk port working natively under wayland.
So far I managed to run games successfully with the software renderer, I don't have much experience with OpenGL so I have not really look this part yet, I have just seen that it uses GLX so there is some work to do.

The easy part was to wrap the X specific stuff in compile-time and run-time checks so that snes9x does not seg fault at launch.
The most important change I made is to send a "draw" signal when S9xDeinitUpdate is called and handle the rendering in the expose callback, because for some reason directly rendering in S9xDeinitUpdate does not work under wayland, even it is working correctly under X11. I tried to do this with the fewest possible changes to the code base.

Is the Wayland support something the snes9x team would like to add ?
I think it could be very useful for several reasons:
 - Wayland is supposed to replace X11 at some point
 - in native Wayland sessions (like Gnome that I use) Wayland applications are rendered nicer than X applications that have to use XWayland
 - Wayland is supposed to be lightweight and performing better than X in less powerful systems like ARM boards (Snes9x is quite popular on this kind of platform)

Moreover, as a side effect, the work I have done makes the gtk port somewhat backend-agnostic and I have successfully ran it on macOS! Considering the macosx port seems unmaintained at the moment and the most recent build I found is a 32-bit one from 2011, I find this interesting (even if gtk on macOS is not as nice as a native application).

Feel free to comment this patches, and if you guys are interested in making it happening I will be very happy to continue working on it!