### PR TITLE
Backport Hermite Resampler bypass code from Libretro version

### DIFF
--- a/apu/hermite_resampler.h
+++ b/apu/hermite_resampler.h
@@ -66,6 +66,13 @@ class HermiteResampler : public Resampler
         void
         read (short *data, int num_samples)
         {
+            //If we are outputting the exact same ratio as the input, pull directly from the input buffer
+            if (r_step == 1.0)
+            {
+                ring_buffer::pull((unsigned char*)data, num_samples * sizeof(short));
+                return;
+            }
+
             assert((num_samples & 1) == 0); // resampler always processes both stereo samples
             int i_position = start >> 1;
             int max_samples = buffer_size >> 1;
@@ -121,6 +128,12 @@ class HermiteResampler : public Resampler
         inline int
         avail (void)
         {
+            //If we are outputting the exact same ratio as the input, find out directly from the input buffer
+            if (r_step == 1.0)
+            {
+                return (ring_buffer::space_filled() + sizeof(short) - 1) / sizeof(short);
+            }
+
             return (int) floor (((size >> 2) - r_frac) / r_step) * 2;
         }
 };


### PR DESCRIPTION
I had already submitted this to the Libretro version, I think I'll do the same here.

This is a change to hermite resampler code to make it operate in "bypass mode" if the ratio is exactly 1, or in other words, the output sampling rate is exactly equal to the input sampling rate.

If the hermite resampler is bypassed, this eliminates the hidden internal state from the audio system, so a savestate will contain all the information needed to generate the exact same samples on the next frame.
It also doesn't need to do any math on the sound samples either, for slightly better performance.