### PR TITLE
macOS cheats: fixed variable rename oversight; typecasting 

### DIFF
--- a/macosx/mac-cheat.cpp
+++ b/macosx/mac-cheat.cpp
@@ -273,7 +273,7 @@ static void InitCheatItems (void)
 
 static void ImportCheatItems (void)
 {
-    int cheat_num = std::min(Cheat.g.size(), MAC_MAX_CHEATS);
+    int cheat_num = std::min((int)Cheat.g.size(), MAC_MAX_CHEATS);
 	for (unsigned int i = 0; i < cheat_num; i++)
 	{
 		citem[i].valid   = true;

--- a/macosx/mac-cheatfinder.cpp
+++ b/macosx/mac-cheatfinder.cpp
@@ -1297,7 +1297,7 @@ static void CheatFinderHandleAddEntryButton (WindowData *cf)
 	if (cfAddress[cfListSelection] > (0x20000 - cfViewNumBytes))
 		PlayAlertSound();
 	else
-	if (Cheat.g.size() + cfViewNumBytes > MAX_CHEATS)
+	if (Cheat.g.size() + cfViewNumBytes > MAC_MAX_CHEATS)
 		AppearanceAlert(kAlertCautionAlert, kS9xMacAlertCFCantAddEntry, kS9xMacAlertCFCantAddEntryHint);
 	else
 		CheatFinderBeginAddEntrySheet(cf);


### PR DESCRIPTION
it builds fine with those changes

also see 77c3017 and #344 