### PR TITLE
gtk: Use datarootdir instead of datadir.

### DIFF
--- a/gtk/data/Makefile.am
+++ b/gtk/data/Makefile.am
@@ -1,42 +1,41 @@
-desktopdir = $(datadir)/applications
+desktopdir = $(datarootdir)/applications
 desktop_DATA = snes9x.desktop
 
-icon16x16dir = $(datadir)/icons/hicolor/16x16/apps
+icon16x16dir = $(datarootdir)/icons/hicolor/16x16/apps
 icon16x16_DATA = snes9x_16x16.png
 
-icon24x24dir = $(datadir)/icons/hicolor/24x24/apps
+icon24x24dir = $(datarootdir)/icons/hicolor/24x24/apps
 icon24x24_DATA = snes9x_24x24.png
 
-icon32x32dir = $(datadir)/icons/hicolor/32x32/apps
+icon32x32dir = $(datarootdir)/icons/hicolor/32x32/apps
 icon32x32_DATA = snes9x_32x32.png
 
-icon64x64dir = $(datadir)/icons/hicolor/64x64/apps
+icon64x64dir = $(datarootdir)/icons/hicolor/64x64/apps
 icon64x64_DATA = snes9x_64x64.png
 
-icon128x128dir = $(datadir)/icons/hicolor/128x128/apps
+icon128x128dir = $(datarootdir)/icons/hicolor/128x128/apps
 icon128x128_DATA = snes9x_128x128.png
 
-icon256x256dir = $(datadir)/icons/hicolor/256x256/apps
+icon256x256dir = $(datarootdir)/icons/hicolor/256x256/apps
 icon256x256_DATA = snes9x_256x256.png
 
-#iconscalabledir = $(datadir)/icons/hicolor/scalable/apps
+#iconscalabledir = $(datarootdir)/icons/hicolor/scalable/apps
 #iconscalable_DATA = snes9x.svg
 
 cheatsdir = $(datadir)/snes9x
 cheats_DATA = ../../data/cheats.bml
 
 install-data-hook:
-	mv -f $(DESTDIR)$(datadir)/icons/hicolor/16x16/apps/snes9x_16x16.png \
-	      $(DESTDIR)$(datadir)/icons/hicolor/16x16/apps/snes9x.png
-	mv -f $(DESTDIR)$(datadir)/icons/hicolor/24x24/apps/snes9x_24x24.png \
-	      $(DESTDIR)$(datadir)/icons/hicolor/24x24/apps/snes9x.png
-	mv -f $(DESTDIR)$(datadir)/icons/hicolor/32x32/apps/snes9x_32x32.png \
-	      $(DESTDIR)$(datadir)/icons/hicolor/32x32/apps/snes9x.png
-	mv -f $(DESTDIR)$(datadir)/icons/hicolor/64x64/apps/snes9x_64x64.png \
-	      $(DESTDIR)$(datadir)/icons/hicolor/64x64/apps/snes9x.png
-	mv -f $(DESTDIR)$(datadir)/icons/hicolor/128x128/apps/snes9x_128x128.png \
-	      $(DESTDIR)$(datadir)/icons/hicolor/128x128/apps/snes9x.png
-	mv -f $(DESTDIR)$(datadir)/icons/hicolor/256x256/apps/snes9x_256x256.png \
-	      $(DESTDIR)$(datadir)/icons/hicolor/256x256/apps/snes9x.png
-	touch -c $(DESTDIR)$(datadir)/icons/hicolor
-
+	mv -f $(DESTDIR)$(datarootdir)/icons/hicolor/16x16/apps/snes9x_16x16.png \
+	      $(DESTDIR)$(datarootdir)/icons/hicolor/16x16/apps/snes9x.png
+	mv -f $(DESTDIR)$(datarootdir)/icons/hicolor/24x24/apps/snes9x_24x24.png \
+	      $(DESTDIR)$(datarootdir)/icons/hicolor/24x24/apps/snes9x.png
+	mv -f $(DESTDIR)$(datarootdir)/icons/hicolor/32x32/apps/snes9x_32x32.png \
+	      $(DESTDIR)$(datarootdir)/icons/hicolor/32x32/apps/snes9x.png
+	mv -f $(DESTDIR)$(datarootdir)/icons/hicolor/64x64/apps/snes9x_64x64.png \
+	      $(DESTDIR)$(datarootdir)/icons/hicolor/64x64/apps/snes9x.png
+	mv -f $(DESTDIR)$(datarootdir)/icons/hicolor/128x128/apps/snes9x_128x128.png \
+	      $(DESTDIR)$(datarootdir)/icons/hicolor/128x128/apps/snes9x.png
+	mv -f $(DESTDIR)$(datarootdir)/icons/hicolor/256x256/apps/snes9x_256x256.png \
+	      $(DESTDIR)$(datarootdir)/icons/hicolor/256x256/apps/snes9x.png
+	touch -c $(DESTDIR)$(datarootdir)/icons/hicolor


### PR DESCRIPTION
Currently snes9x ignores `--datarootdir` and only uses `--datadir`. This is a problem because I would like to change the install path for `cheats.bml` without changing the path for the icons and desktop file.

So using `--datarootdir` sets the path for all data including locales, icons, the desktop file and `cheats.bml` while `-datadir` only sets the path for `cheats.bml` which can override `--datarootdir` for that one file.

This seems to work as desired here, but please review to make sure its right.

Edit: From `./configure ---help`.
```
  --datarootdir=DIR       read-only arch.-independent data root [PREFIX/share]
  --datadir=DIR           read-only architecture-independent data [DATAROOTDIR]
```