### PR TITLE
Move `VRAMReadBuffer` from `IPPU` to `PPU`, then add to savestate

### DIFF
--- a/ppu.cpp
+++ b/ppu.cpp
@@ -721,10 +721,10 @@ void S9xSetPPU (uint8 Byte, uint16 Address)
 					uint32 addr = PPU.VMA.Address;
 					uint32 rem = addr & PPU.VMA.Mask1;
 					uint32 address = (addr & ~PPU.VMA.Mask1) + (rem >> PPU.VMA.Shift) + ((rem & (PPU.VMA.FullGraphicCount - 1)) << 3);
-					IPPU.VRAMReadBuffer = READ_WORD(Memory.VRAM + ((address << 1) & 0xffff));
+					PPU.VRAMReadBuffer = READ_WORD(Memory.VRAM + ((address << 1) & 0xffff));
 				}
 				else
-					IPPU.VRAMReadBuffer = READ_WORD(Memory.VRAM + ((PPU.VMA.Address << 1) & 0xffff));
+					PPU.VRAMReadBuffer = READ_WORD(Memory.VRAM + ((PPU.VMA.Address << 1) & 0xffff));
 
 				break;
 
@@ -737,10 +737,10 @@ void S9xSetPPU (uint8 Byte, uint16 Address)
 					uint32 addr = PPU.VMA.Address;
 					uint32 rem = addr & PPU.VMA.Mask1;
 					uint32 address = (addr & ~PPU.VMA.Mask1) + (rem >> PPU.VMA.Shift) + ((rem & (PPU.VMA.FullGraphicCount - 1)) << 3);
-					IPPU.VRAMReadBuffer = READ_WORD(Memory.VRAM + ((address << 1) & 0xffff));
+					PPU.VRAMReadBuffer = READ_WORD(Memory.VRAM + ((address << 1) & 0xffff));
 				}
 				else
-					IPPU.VRAMReadBuffer = READ_WORD(Memory.VRAM + ((PPU.VMA.Address << 1) & 0xffff));
+					PPU.VRAMReadBuffer = READ_WORD(Memory.VRAM + ((PPU.VMA.Address << 1) & 0xffff));
 
 				break;
 
@@ -1308,7 +1308,7 @@ uint8 S9xGetPPU (uint16 Address)
 				return (PPU.OpenBus1 = byte);
 
 			case 0x2139: // VMDATALREAD
-				byte = IPPU.VRAMReadBuffer & 0xff;
+				byte = PPU.VRAMReadBuffer & 0xff;
 				if (!PPU.VMA.High)
 				{
 					if (PPU.VMA.FullGraphicCount)
@@ -1316,10 +1316,10 @@ uint8 S9xGetPPU (uint16 Address)
 						uint32 addr = PPU.VMA.Address;
 						uint32 rem = addr & PPU.VMA.Mask1;
 						uint32 address = (addr & ~PPU.VMA.Mask1) + (rem >> PPU.VMA.Shift) + ((rem & (PPU.VMA.FullGraphicCount - 1)) << 3);
-						IPPU.VRAMReadBuffer = READ_WORD(Memory.VRAM + ((address << 1) & 0xffff));
+						PPU.VRAMReadBuffer = READ_WORD(Memory.VRAM + ((address << 1) & 0xffff));
 					}
 					else
-						IPPU.VRAMReadBuffer = READ_WORD(Memory.VRAM + ((PPU.VMA.Address << 1) & 0xffff));
+						PPU.VRAMReadBuffer = READ_WORD(Memory.VRAM + ((PPU.VMA.Address << 1) & 0xffff));
 
 					PPU.VMA.Address += PPU.VMA.Increment;
 				}
@@ -1330,7 +1330,7 @@ uint8 S9xGetPPU (uint16 Address)
 				return (PPU.OpenBus1 = byte);
 
 			case 0x213a: // VMDATAHREAD
-				byte = (IPPU.VRAMReadBuffer >> 8) & 0xff;
+				byte = (PPU.VRAMReadBuffer >> 8) & 0xff;
 				if (PPU.VMA.High)
 				{
 					if (PPU.VMA.FullGraphicCount)
@@ -1338,10 +1338,10 @@ uint8 S9xGetPPU (uint16 Address)
 						uint32 addr = PPU.VMA.Address;
 						uint32 rem = addr & PPU.VMA.Mask1;
 						uint32 address = (addr & ~PPU.VMA.Mask1) + (rem >> PPU.VMA.Shift) + ((rem & (PPU.VMA.FullGraphicCount - 1)) << 3);
-						IPPU.VRAMReadBuffer = READ_WORD(Memory.VRAM + ((address << 1) & 0xffff));
+						PPU.VRAMReadBuffer = READ_WORD(Memory.VRAM + ((address << 1) & 0xffff));
 					}
 					else
-						IPPU.VRAMReadBuffer = READ_WORD(Memory.VRAM + ((PPU.VMA.Address << 1) & 0xffff));
+						PPU.VRAMReadBuffer = READ_WORD(Memory.VRAM + ((PPU.VMA.Address << 1) & 0xffff));
 
 					PPU.VMA.Address += PPU.VMA.Increment;
 				}
@@ -2095,7 +2095,7 @@ void S9xSoftResetPPU (void)
 	memset(IPPU.TileCached[TILE_2BIT_ODD], 0,  MAX_2BIT_TILES);
 	memset(IPPU.TileCached[TILE_4BIT_EVEN], 0, MAX_4BIT_TILES);
 	memset(IPPU.TileCached[TILE_4BIT_ODD], 0,  MAX_4BIT_TILES);
-	IPPU.VRAMReadBuffer = 0; // XXX: FIXME: anything better?
+	PPU.VRAMReadBuffer = 0; // XXX: FIXME: anything better?
 	GFX.InterlaceFrame = 0;
 	IPPU.Interlace = FALSE;
 	IPPU.InterlaceOBJ = FALSE;

--- a/ppu.h
+++ b/ppu.h
@@ -227,7 +227,6 @@ struct InternalPPU
 	bool8	OBJChanged;
 	uint8	*TileCache[7];
 	uint8	*TileCached[7];
-	uint16	VRAMReadBuffer;
 	bool8	Interlace;
 	bool8	InterlaceOBJ;
 	bool8	PseudoHires;
@@ -378,6 +377,8 @@ struct SPPU
 
 	uint8	OpenBus1;
 	uint8	OpenBus2;
+
+	uint16	VRAMReadBuffer;
 };
 
 extern uint16				SignExtend[2];

--- a/snapshot.cpp
+++ b/snapshot.cpp
@@ -531,7 +531,8 @@ static FreezeData	SnapPPU[] =
 	INT_ENTRY(6, HDMA),
 	INT_ENTRY(6, HDMAEnded),
 	INT_ENTRY(6, OpenBus1),
-	INT_ENTRY(6, OpenBus2)
+	INT_ENTRY(6, OpenBus2),
+	INT_ENTRY(11, VRAMReadBuffer)
 };
 
 #undef STRUCT


### PR DESCRIPTION
Move `VRAMReadBuffer` from `IPPU` to `PPU`, then add to savestates.  Tagged as version 11.  Fixes RunAhead in "Battle Grand Prix".