### PR TITLE
MacOSX: explicitly set default values for new options

### DIFF
--- a/macosx/mac-os.mm
+++ b/macosx/mac-os.mm
@@ -3235,6 +3235,12 @@ static void Initialize (void)
 	Settings.StretchScreenshots = 1;
 	Settings.SnapshotScreenshots = true;
 	Settings.OpenGLEnable = true;
+	Settings.SuperFXClockMultiplier = 100;
+	Settings.InterpolationMethod = DSP_INTERPOLATION_GAUSSIAN;
+	Settings.MaxSpriteTilesPerLine = 34;
+	Settings.OneClockCycle = 6;
+	Settings.OneSlowClockCycle = 8;
+	Settings.TwoClockCycles = 12;
 
 	for (int a = 0; a < kWindowCount; a++)
 	{


### PR DESCRIPTION
MacOSX port should explicitly set default values for new configuration options added in fdae8cc, 6d15bf7 and cf5681a.