### PR TITLE
Swap joypads over Netplay

### DIFF
--- a/controls.cpp
+++ b/controls.cpp
@@ -2628,6 +2628,15 @@ void S9xApplyCommand (s9xcommand_t cmd, int16 data1, int16 data2)
 							S9xSetInfoString("Cannot swap pads: port 2 is not a joypad");
 							break;
 						}
+						
+						if (Settings.NetPlay && data2 != 1) { //data2 == 1 means it's sent by the netplay code
+							if (Settings.NetPlayServer) {
+								S9xNPSendJoypadSwap();
+							} else {
+								S9xSetInfoString("Netplay Client cannot swap pads.");
+								break;
+							}
+						}
 
 						newcontrollers[1] = curcontrollers[0];
 						newcontrollers[0] = curcontrollers[1];

--- a/netplay.cpp
+++ b/netplay.cpp
@@ -204,6 +204,7 @@
 #include <sys/types.h>
 
 #include "snes9x.h"
+#include "controls.h"
 
 #ifdef __WIN32__
 	#include <winsock.h>
@@ -684,7 +685,13 @@ bool8 S9xNPWaitForHeartBeat ()
 				else
 					S9xNPSetWarning("CLIENT: Server has resumed.");
                 break;
-            case NP_SERV_LOAD_ROM:
+		case NP_SERV_JOYPAD_SWAP:
+#ifdef NP_DEBUG
+			printf("CLIENT: Joypad Swap received @%ld\n", S9xGetMilliTime() - START);
+#endif
+			S9xApplyCommand(S9xGetCommandT("SwapJoypads"), 1, 1);
+			break;
+        case NP_SERV_LOAD_ROM:
 #ifdef NP_DEBUG
                 printf ("CLIENT: LOAD_ROM received @%ld\n", S9xGetMilliTime () - START);
 #endif

--- a/netplay.h
+++ b/netplay.h
@@ -241,6 +241,8 @@
 #define NP_SERV_FREEZE_FILE 6
 #define NP_SERV_SRAM_DATA 7
 #define NP_SERV_READY 8
+// ...
+#define NP_SERV_JOYPAD_SWAP 12
 
 struct SNPClient
 {
@@ -382,6 +384,7 @@ void S9xNPServerAddTask (uint32 task, void *data);
 
 bool8 S9xNPStartServer (int port);
 void S9xNPStopServer ();
+void S9xNPSendJoypadSwap ();
 #ifdef __WIN32__
 #define S9xGetMilliTime timeGetTime
 #else

--- a/server.cpp
+++ b/server.cpp
@@ -869,6 +869,20 @@ void S9xNPSendServerPause (bool8 paused)
     S9xNPSendToAllClients (pause, 7);
 }
 
+void S9xNPSendJoypadSwap()
+{
+#ifdef NP_DEBUG
+	printf("SERVER: Swap Joypads - @%ld\n", S9xGetMilliTime() - START);
+#endif
+	uint8 swap[7];
+	uint8 *ptr = swap;
+	*ptr++ = NP_SERV_MAGIC;
+	*ptr++ = 0;
+	*ptr++ = NP_SERV_JOYPAD_SWAP;
+	WRITE_LONG(ptr, 7);
+	S9xNPSendToAllClients(swap, 7);
+}
+
 void S9xNPServerLoop (void *)
 {
 #ifdef __WIN32__

--- a/win32/snes9xw.vcxproj
+++ b/win32/snes9xw.vcxproj
@@ -92,6 +92,7 @@
     <IntDir>$(SolutionDir)_Intermediate\$(ProjectName)\$(Configuration)\$(PlatformTarget)\</IntDir>
     <TargetName>$(ProjectName)</TargetName>
     <IncludePath>$(DXSDK_DIR)include;$(CG_INC_PATH);$(IncludePath)</IncludePath>
+    <IncludePath>$(DXSDK_DIR)include;$(CG_INC_PATH);$(IncludePath);$(DXSDK_DIR)\include</IncludePath>
     <LibraryPath>$(DXSDK_DIR)Lib\$(PlatformTarget);$(CG_LIB_PATH);$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release Unicode|x64'">


### PR DESCRIPTION
Someone smarter than me can probably figure out a more "proper" way to do this, but I hate RetroArch and wanted an easy way to Swap P1 and P2 without both players having to press the button at the same time. Only the host may send the swap. This is most likely not even what this keybind is supposed to be used for, but it just so happens to work precisely how I needed it to. Again, someone smarter and more familiar with both C++ and S9X should probably look at this critically.

This is mostly going to be used by me to play some 2-player 1-console randomizer games (SMZ3, Super Metroid, LttP, etc).