### PR TITLE
Copier Headers fix for Libretro (alternative PR)

### DIFF
--- a/memmap.cpp
+++ b/memmap.cpp
@@ -1382,11 +1382,25 @@ int CMemory::ScoreLoROM (bool8 skip_header, int32 romoff)
 
 uint32 CMemory::HeaderRemove (uint32 size, uint8 *buf)
 {
+	const uint8* buf2 = buf;
+	uint32 size2 = size;
+	if (HeaderRemove(&size2, &buf2))
+	{
+		memmove(buf, buf2, size2);
+	}
+	return size;
+}
+
+bool CMemory::HeaderRemove (uint32 *size_p, const uint8 **buf_p)
+{
+	uint32 &size = *size_p;
+	const uint8 *&buf = *buf_p;
+
 	uint32	calc_size = (size / 0x2000) * 0x2000;
 
 	if ((size - calc_size == 512 && !Settings.ForceNoHeader) || Settings.ForceHeader)
 	{
-		uint8	*NSRTHead = buf + 0x1D0; // NSRT Header Location
+		const uint8	*NSRTHead = buf + 0x1D0; // NSRT Header Location
 
 		// detect NSRT header
 		if (!strncmp("NSRT", (char *) &NSRTHead[24], 4))
@@ -1400,12 +1414,13 @@ uint32 CMemory::HeaderRemove (uint32 size, uint8 *buf)
 			}
 		}
 
-		memmove(buf, buf + 512, calc_size);
+		buf += 512;
 		HeaderCount++;
 		size -= 512;
+		return true;
 	}
 
-	return (size);
+	return false;
 }
 
 uint32 CMemory::FileLoader (uint8 *buffer, const char *filename, uint32 maxsize)

--- a/memmap.h
+++ b/memmap.h
@@ -287,6 +287,7 @@ struct CMemory
 	int		ScoreHiROM (bool8, int32 romoff = 0);
 	int		ScoreLoROM (bool8, int32 romoff = 0);
 	uint32	HeaderRemove (uint32, uint8 *);
+	bool	HeaderRemove (uint32*, const uint8 **);
 	uint32	FileLoader (uint8 *, const char *, uint32);
     uint32  MemLoader (uint8 *, const char*, uint32);
     bool8   LoadROMMem (const uint8 *, uint32);


### PR DESCRIPTION
This is an alternative to #420 which makes Libretro's file loader use the same header removal code as `Memory.LoadROM`, whereas before it was using no header removal code at all..

The `HeaderRemove` function is also refactored to support const pointers to avoid mutating the input data.  The previous behavior (call `memmove` on the rom) is also in there as well when calling the previous version of the function.

I still have reservations about always treating sizes exactly 512 bytes over a multiple of 8K to be a 100% chance of being a copier header, but this will bring Libretro file loading in line with the other forms of file loading.