### PR TITLE
Lightgun improvements

### DIFF
--- a/apu/bapu/dsp/blargg_config.h
+++ b/apu/bapu/dsp/blargg_config.h
@@ -10,7 +10,9 @@
 #endif
 
 // Uncomment to enable platform-specific (and possibly non-portable) optimizations
+#if !defined(__CELLOS_LV2__)
 #define BLARGG_NONPORTABLE 1
+#endif
 
 // Uncomment if automatic byte-order determination doesn't work
 //#define BLARGG_BIG_ENDIAN 1

--- a/c4emu.cpp
+++ b/c4emu.cpp
@@ -1207,10 +1207,11 @@ void S9xSetC4 (uint8 byte, uint16 Address)
 					if (Memory.C4RAM[0x1f4d] != 0x0e)
 						printf("$7f4d=%02x, expected 0e for command 54 %02x\n", Memory.C4RAM[0x1f4d], Memory.C4RAM[0x1f4d]);
 				#endif
-					int64	a = SAR((int64) READ_3WORD(Memory.C4RAM + 0x1f80) << 40, 40);
-					//printf("%08X%08X\n", (uint32) (a>>32), (uint32) (a&0xFFFFFFFF));
+					int64   b = (int64) READ_3WORD(Memory.C4RAM + 0x1f80);
+					int64   c = b << 40;
+					int64	a = SAR(c, 30);
+					a = SAR(c, 10);
 					a *= a;
-					//printf("%08X%08X\n", (uint32) (a>>32), (uint32) (a&0xFFFFFFFF));
 					WRITE_3WORD(Memory.C4RAM + 0x1f83, a);
 					WRITE_3WORD(Memory.C4RAM + 0x1f86, (a >> 24));
 					break;

--- a/libretro/Makefile
+++ b/libretro/Makefile
@@ -177,18 +177,12 @@ else ifneq (,$(filter $(platform), ps3 sncps3 psl1ght))
 
    # PS3
    else ifneq (,$(findstring ps3,$(platform)))
-      CFLAGS += -flto
-      CXXFLAGS += -flto
-      LDFLAGS += -flto
       CC = $(CELL_SDK)/host-win32/ppu/bin/ppu-lv2-gcc.exe
       CXX = $(CELL_SDK)/host-win32/ppu/bin/ppu-lv2-g++.exe
       AR = $(CELL_SDK)/host-win32/ppu/bin/ppu-lv2-ar.exe
 
    # Lightweight PS3 Homebrew SDK
    else ifneq (,$(findstring psl1ght,$(platform)))
-      CFLAGS += -flto
-      CXXFLAGS += -flto
-      LDFLAGS += -flto
       CC = $(PS3DEV)/ppu/bin/ppu-gcc$(EXE_EXT)
       CXX = $(PS3DEV)/ppu/bin/ppu-g++$(EXE_EXT)
       AR = $(PS3DEV)/ppu/bin/ppu-ar$(EXE_EXT)

--- a/libretro/Makefile
+++ b/libretro/Makefile
@@ -202,9 +202,6 @@ else ifeq ($(platform), xenon)
 
 # Nintendo Game Cube / Wii / WiiU
 else ifneq (,$(filter $(platform), ngc wii wiiu))
-   CFLAGS += -flto
-   CXXFLAGS += -flto
-   LDFLAGS += -flto
    TARGET := $(TARGET_NAME)_libretro_$(platform).a
    CC = $(DEVKITPPC)/bin/powerpc-eabi-gcc$(EXE_EXT)
    CXX = $(DEVKITPPC)/bin/powerpc-eabi-g++$(EXE_EXT)

--- a/libretro/Makefile
+++ b/libretro/Makefile
@@ -1,6 +1,7 @@
 DEBUG = 0
 HAVE_EXCEPTIONS = 0
 LAGFIX=1
+HAVE_STRINGS_H = 1
 
 SPACE :=
 SPACE := $(SPACE) $(SPACE)
@@ -167,6 +168,7 @@ else ifneq (,$(filter $(platform), ps3 sncps3 psl1ght))
    TARGET := $(TARGET_NAME)_libretro_$(platform).a
    CXXFLAGS += -DBLARGG_BIG_ENDIAN=1 -D__ppc__
    STATIC_LINKING = 1
+   HAVE_STRINGS_H = 0
 
    # sncps3
    ifneq (,$(findstring sncps3,$(platform)))
@@ -517,9 +519,12 @@ endif
 CXXFLAGS	+= $(CODE_DEFINES) $(WARNINGS_DEFINES) $(fpic)
 CXXFLAGS	+= -DRIGHTSHIFT_IS_SAR -D__LIBRETRO__ -DALLOW_CPU_OVERCLOCK
 CFLAGS		= $(CXXFLAGS)
-
+CFLAGS          += -DHAVE_STDINT_H
+CXXFLAGS        += -DHAVE_STDINT_H
 ifeq (,$(findstring msvc,$(platform)))
+ifeq ($(HAVE_STRINGS_H), 1)
 CXXFLAGS += -DHAVE_STRINGS_H
+endif
 CXXFLAGS += -fno-rtti -pedantic 
 ifneq ($(HAVE_EXCEPTIONS), 1)
    CXXFLAGS += -fno-exceptions

--- a/sha256.cpp
+++ b/sha256.cpp
@@ -13,8 +13,9 @@
 *********************************************************************/
 
 /*************************** HEADER FILES ***************************/
+#include <stdint.h>
 #include <stdlib.h>
-#include <memory.h>
+#include <string.h>
 
 /****************************** MACROS ******************************/
 #define ROTLEFT(a,b) (((a) << (b)) | ((a) >> (32-(b))))
@@ -35,7 +36,7 @@ typedef unsigned int  WORD;             /* 32-bit word, change to "long" for 16-
 typedef struct {
 	BYTE data[64];
 	WORD datalen;
-	unsigned long long bitlen;
+	uint64_t bitlen;
 	WORD state[8];
 } SHA256_CTX;
 


### PR DESCRIPTION
(submitting PR as requested by @twinaphex )

This patch improves light-gun support using the newer API.

Use absolute positions from the front-end instead of old relative based system.
Fixed turbo button instability - toggle once only on press.
Support for the special reload button when using Justifier.
Support for Two Justifiers - second gun is assigned via port 3 (IRL it's daisy chained to the first gun)