### PR TITLE
libretro: Allow overriding -flto.

### DIFF
--- a/libretro/Makefile
+++ b/libretro/Makefile
@@ -2,6 +2,7 @@ DEBUG = 0
 HAVE_EXCEPTIONS = 0
 HAVE_STRINGS_H = 1
 
+LTO ?= -flto
 SPACE :=
 SPACE := $(SPACE) $(SPACE)
 BACKSLASH :=
@@ -45,9 +46,9 @@ endif
 
 # Unix
 ifneq (,$(findstring unix,$(platform)))
-   CFLAGS += -flto
-   CXXFLAGS += -flto
-   LDFLAGS += -flto
+   CFLAGS += $(LTO)
+   CXXFLAGS += $(LTO)
+   LDFLAGS += $(LTO)
    TARGET := $(TARGET_NAME)_libretro.so
    fpic := -fPIC
    ifneq ($(findstring SunOS,$(shell uname -a)),)
@@ -70,9 +71,9 @@ ifneq (,$(findstring unix,$(platform)))
 
 # OS X
 else ifeq ($(platform), osx)
-   CFLAGS += -flto
-   CXXFLAGS += -flto
-   LDFLAGS += -flto
+   CFLAGS += $(LTO)
+   CXXFLAGS += $(LTO)
+   LDFLAGS += $(LTO)
    TARGET := $(TARGET_NAME)_libretro.dylib
    fpic := -fPIC
    SHARED := -dynamiclib
@@ -102,9 +103,9 @@ else ifeq ($(platform), libnx)
 
 # iOS
 else ifneq (,$(findstring ios,$(platform)))
-   CFLAGS += -flto
-   CXXFLAGS += -flto
-   LDFLAGS += -flto
+   CFLAGS += $(LTO)
+   CXXFLAGS += $(LTO)
+   LDFLAGS += $(LTO)
    TARGET := $(TARGET_NAME)_libretro_ios.dylib
    fpic := -fPIC
    SHARED := -dynamiclib
@@ -134,9 +135,9 @@ else ifneq (,$(findstring ios,$(platform)))
 
 # Theos
 else ifeq ($(platform), theos_ios)
-   CFLAGS += -flto
-   CXXFLAGS += -flto
-   LDFLAGS += -flto
+   CFLAGS += $(LTO)
+   CXXFLAGS += $(LTO)
+   LDFLAGS += $(LTO)
    DEPLOYMENT_IOSVERSION = 5.0
    TARGET = iphone:latest:$(DEPLOYMENT_IOSVERSION)
    ARCHS = armv7 armv7s
@@ -159,9 +160,9 @@ else ifeq ($(platform), qnx)
 
 # Vita
 else ifeq ($(platform), vita)
-   CFLAGS += -flto
-   CXXFLAGS += -flto
-   LDFLAGS += -flto
+   CFLAGS += $(LTO)
+   CXXFLAGS += $(LTO)
+   LDFLAGS += $(LTO)
    TARGET := $(TARGET_NAME)_libretro_$(platform).so
    fpic := -fPIC
    CC = arm-vita-eabi-gcc$(EXE_EXT)
@@ -199,9 +200,9 @@ else ifneq (,$(filter $(platform), ps3 sncps3 psl1ght))
 
 # Xbox 360
 else ifeq ($(platform), xenon)
-   CFLAGS += -flto
-   CXXFLAGS += -flto
-   LDFLAGS += -flto
+   CFLAGS += $(LTO)
+   CXXFLAGS += $(LTO)
+   LDFLAGS += $(LTO)
    TARGET := $(TARGET_NAME)_libretro_xenon360.a
    CC = xenon-gcc$(EXE_EXT)
    CXX = xenon-g++$(EXE_EXT)
@@ -465,9 +466,9 @@ CFLAGS += -D_CRT_SECURE_NO_DEPRECATE
 CXXFLAGS += -D_CRT_SECURE_NO_DEPRECATE
 # Windows
 else
-   CFLAGS += -flto
-   CXXFLAGS += -flto
-   LDFLAGS += -flto
+   CFLAGS += $(LTO)
+   CXXFLAGS += $(LTO)
+   LDFLAGS += $(LTO)
    TARGET := $(TARGET_NAME)_libretro.dll
    CC = gcc
    CXX = g++
@@ -569,7 +570,7 @@ $(TARGET): $(OBJECTS)
 ifeq ($(STATIC_LINKING), 1)
 	$(AR) rcs $@ $(OBJECTS)
 else
-	$(LD) $(fpic) $(SHARED) $(LINKOUT)$@ $(OBJECTS) $(LDFLAGS) $(LIBS)
+	+$(LD) $(fpic) $(SHARED) $(LINKOUT)$@ $(OBJECTS) $(LDFLAGS) $(LIBS)
 endif
 
 %.o: %.cpp 


### PR DESCRIPTION
With some users it could be handy to set `-flto` manually, for example with gcc its possible to get a speed up for linking with `-flto=jobserver`.

I added the `+` since gcc documentation claims its needed, its part of the POSIX spec so it should not hurt?
```
     You can also specify '-flto=jobserver' to use GNU make's job server
     mode to determine the number of parallel jobs.  This is useful when
     the Makefile calling GCC is already executing in parallel.  You
     must prepend a '+' to the command recipe in the parent Makefile for
     this to work.  This option likely only works if 'MAKE' is GNU make.
```
From the `gcc.info` page.

The `make(1)` posix spec.
```
+
    If the command prefix contains a <plus-sign>, this indicates a makefile command line
    that shall be executed even if -n, -q, or -t is specified.
```
http://pubs.opengroup.org/onlinepubs/9699919799/utilities/make.html

Note that `-flto=` options are not compatible between gcc and clang so that we can't force `-flto=jobserver` in the Makefile unfortunately.

The credit for the idea goes to the current snes9x.SlackBuild maintainer (Also includes the libretro core), I just implemented the changes.