### PR TITLE
Remove unused ReverseStereo

### DIFF
--- a/snes9x.h
+++ b/snes9x.h
@@ -235,7 +235,6 @@ struct SSettings
 	uint32	SoundPlaybackRate;
 	uint32	SoundInputRate;
 	bool8	Stereo;
-	bool8	ReverseStereo;
 	bool8	Mute;
 	bool8	DynamicRateControl;
 	int32	DynamicRateLimit; /* Multiplied by 1000 */


### PR DESCRIPTION
As part of the APU refactor:
https://github.com/snes9xgit/snes9x/commit/1ba69b0d9c8508d142374ef4bd3e264954a9f20e