### PR TITLE
Add option to show time for GTK version

### DIFF
--- a/gfx.cpp
+++ b/gfx.cpp
@@ -26,6 +26,7 @@ void (*S9xCustomDisplayString) (const char *, int, int, bool, int) = NULL;
 
 static void SetupOBJ (void);
 static void DrawOBJS (int);
+static void DisplayTime (void);
 static void DisplayFrameRate (void);
 static void DisplayPressedKeys (void);
 static void DisplayWatchedAddresses (void);
@@ -1838,6 +1839,20 @@ static void S9xDisplayStringType (const char *string, int linesFromBottom, int p
     S9xDisplayString (string, linesFromBottom, pixelsFromLeft, allowWrap);
 }
 
+static void DisplayTime (void)
+{
+	char string[10];
+	
+	time_t rawtime;
+	struct tm *timeinfo;
+
+	time (&rawtime);
+	timeinfo = localtime(&rawtime);
+
+	sprintf(string, "%u:%u", timeinfo->tm_hour, timeinfo->tm_min);
+	S9xDisplayString(string, 3, IPPU.RenderedScreenWidth - (font_width - 1) * strlen(string) - 1, false);
+}
+
 static void DisplayFrameRate (void)
 {
 	char	string[10];
@@ -2031,6 +2046,8 @@ static void DisplayWatchedAddresses (void)
 
 void S9xDisplayMessages (uint16 *screen, int ppl, int width, int height, int scale)
 {
+	DisplayTime(); // Todo: make a setting.
+
 	if (Settings.DisplayFrameRate)
 		DisplayFrameRate();
 

--- a/gfx.cpp
+++ b/gfx.cpp
@@ -2046,8 +2046,9 @@ static void DisplayWatchedAddresses (void)
 
 void S9xDisplayMessages (uint16 *screen, int ppl, int width, int height, int scale)
 {
-	DisplayTime();
-
+	if (Settings.DisplayTime)
+		DisplayTime();
+		
 	if (Settings.DisplayFrameRate)
 		DisplayFrameRate();
 

--- a/gfx.cpp
+++ b/gfx.cpp
@@ -1849,8 +1849,8 @@ static void DisplayTime (void)
 	time (&rawtime);
 	timeinfo = localtime(&rawtime);
 
-	sprintf(string, "%u:%u", timeinfo->tm_hour, timeinfo->tm_min);
-	S9xDisplayString(string, 3, IPPU.RenderedScreenWidth - (font_width - 1) * strlen(string) - 1, false);
+	sprintf(string, "%02u:%02u", timeinfo->tm_hour, timeinfo->tm_min);
+	S9xDisplayString(string, 0, 0, false);
 }
 
 static void DisplayFrameRate (void)
@@ -2046,7 +2046,7 @@ static void DisplayWatchedAddresses (void)
 
 void S9xDisplayMessages (uint16 *screen, int ppl, int width, int height, int scale)
 {
-	DisplayTime(); // Todo: make a setting.
+	DisplayTime();
 
 	if (Settings.DisplayFrameRate)
 		DisplayFrameRate();

--- a/gtk/src/gtk_config.cpp
+++ b/gtk/src/gtk_config.cpp
@@ -165,6 +165,7 @@ int Snes9xConfig::load_defaults ()
     Settings.AutoSaveDelay = 0;
     Settings.SkipFrames = 0;
     Settings.Transparency = true;
+    Settings.DisplayTime = false;
     Settings.DisplayFrameRate = false;
     Settings.SixteenBitSound = true;
     Settings.Stereo = true;
@@ -341,6 +342,7 @@ int Snes9xConfig::save_config_file ()
 #undef z
 #define z "Emulation::"
     outbool (cf, z"EmulateTransparency", Settings.Transparency);
+    outbool (cf, z"DisplayTime", Settings.DisplayTime);
     outbool (cf, z"DisplayFrameRate", Settings.DisplayFrameRate);
     outbool (cf, z"DisplayPressedKeys", Settings.DisplayPressedKeys);
     cf.SetInt (z"SpeedControlMethod", Settings.SkipFrames, "0: Time the frames to 50 or 60Hz, 1: Same, but skip frames if too slow, 2: Synchronize to the sound buffer, 3: Unlimited, except potentially by vsync");
@@ -570,6 +572,7 @@ int Snes9xConfig::load_config_file ()
 #undef z
 #define z "Emulation::"
     inbool (z"EmulateTransparency", Settings.Transparency);
+    inbool (z"DisplayTime", Settings.DisplayTime);
     inbool (z"DisplayFrameRate", Settings.DisplayFrameRate);
     inbool (z"DisplayPressedKeys", Settings.DisplayPressedKeys);
     inint (z"SpeedControlMethod", Settings.SkipFrames);

--- a/gtk/src/gtk_preferences.cpp
+++ b/gtk/src/gtk_preferences.cpp
@@ -607,6 +607,7 @@ void
 Snes9xPreferences::move_settings_to_dialog ()
 {
     set_check ("full_screen_on_open",       config->full_screen_on_open);
+    set_check ("show_time",                 Settings.DisplayTime);
     set_check ("show_frame_rate",           Settings.DisplayFrameRate);
     set_check ("show_pressed_keys",         Settings.DisplayPressedKeys);
     set_check ("change_display_resolution", config->change_display_resolution);
@@ -823,6 +824,7 @@ Snes9xPreferences::get_settings_from_dialog ()
 #endif
 
     config->full_screen_on_open       = get_check ("full_screen_on_open");
+    Settings.DisplayTime              = get_check ("show_time");
     Settings.DisplayFrameRate         = get_check ("show_frame_rate");
     Settings.DisplayPressedKeys       = get_check ("show_pressed_keys");
     config->scale_to_fit              = get_check ("scale_to_fit");

--- a/gtk/src/snes9x.ui
+++ b/gtk/src/snes9x.ui
@@ -2762,6 +2762,21 @@
                               </packing>
                             </child>
                             <child>
+                              <object class="GtkCheckButton" id="show_time">
+                                <property name="label" translatable="yes">Show time</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">False</property>
+                                <property name="use_underline">True</property>
+                                <property name="draw_indicator">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                            <child>
                               <object class="GtkCheckButton" id="show_frame_rate">
                                 <property name="label" translatable="yes">Show frame rate</property>
                                 <property name="visible">True</property>

--- a/snes9x.cpp
+++ b/snes9x.cpp
@@ -250,6 +250,7 @@ void S9xLoadConfigFiles (char **argv, int argc)
 	Settings.SupportHiRes               =  conf.GetBool("Display::HiRes",                      true);
 	Settings.Transparency               =  conf.GetBool("Display::Transparency",               true);
 	Settings.DisableGraphicWindows      = !conf.GetBool("Display::GraphicWindows",             true);
+	Settings.DisplayTime				=  conf.GetBool("Display::DisplayTime",                false);
 	Settings.DisplayFrameRate           =  conf.GetBool("Display::DisplayFrameRate",           false);
 	Settings.DisplayWatchedAddresses    =  conf.GetBool("Display::DisplayWatchedAddresses",    false);
 	Settings.DisplayPressedKeys         =  conf.GetBool("Display::DisplayInput",               false);
@@ -368,6 +369,7 @@ void S9xUsage (void)
 	S9xMessage(S9X_INFO, S9X_USAGE, "");
 
 	// DISPLAY OPTIONS
+	S9xMessage(S9X_INFO, S9X_USAGE, "-displaytime                    Display the time");
 	S9xMessage(S9X_INFO, S9X_USAGE, "-displayframerate               Display the frame rate counter");
 	S9xMessage(S9X_INFO, S9X_USAGE, "-displaykeypress                Display input of all controllers and peripherals");
 	S9xMessage(S9X_INFO, S9X_USAGE, "-nohires                        (Not recommended) Disable support for hi-res and");
@@ -539,6 +541,9 @@ char * S9xParseArgs (char **argv, int argc)
 
 			// DISPLAY OPTIONS
 
+			if (!strcasecmp(argv[i], "-displaytime"))
+				Settings.DisplayTime = TRUE;
+			else
 			if (!strcasecmp(argv[i], "-displayframerate"))
 				Settings.DisplayFrameRate = TRUE;
 			else

--- a/snes9x.h
+++ b/snes9x.h
@@ -247,6 +247,7 @@ struct SSettings
 	uint8	BG_Forced;
 	bool8	DisableGraphicWindows;
 
+	bool8	DisplayTime;
 	bool8	DisplayFrameRate;
 	bool8	DisplayWatchedAddresses;
 	bool8	DisplayPressedKeys;

--- a/unix/snes9x.conf.default
+++ b/unix/snes9x.conf.default
@@ -28,6 +28,7 @@ Mute = FALSE
 HiRes = TRUE
 Transparency = TRUE
 GraphicWindows = TRUE
+DisplayTime = FALSE
 DisplayFrameRate = FALSE
 DisplayWatchedAddresses = FALSE
 DisplayInput = FALSE


### PR DESCRIPTION
For issue #109 
I do not have a Mac nor Windows.

By default showing time is disabled. Time shows in the bottom left corner. (Time in screenshots is 12:01 AM)
![Screenshot_20190512_000202](https://user-images.githubusercontent.com/37668804/57577627-4294e680-7449-11e9-9e11-bc292ffc3160.png)
![Screenshot_20190512_000221](https://user-images.githubusercontent.com/37668804/57577628-44f74080-7449-11e9-8bd7-4ce448d78add.png)

