### PR TITLE
Fix GTK build on PowerPC systems with Altivec

### DIFF
--- a/gtk/meson.build
+++ b/gtk/meson.build
@@ -6,7 +6,7 @@ project('snes9x-gtk',
 args = ['-DSNES9X_GTK', '-DUNZIP_SUPPORT', '-DNETPLAY_SUPPORT', '-DJMA_SUPPORT', '-Wall', '-W', '-Wno-unused-parameter']
 srcs = []
 deps = []
-includes = ['../apu/bapu', '../', 'src']
+includes = ['../apu/bapu', '../', 'src', '../ppc']
 warns = []
 
 prefix = get_option('prefix')

--- a/ppc/altivec.h
+++ b/ppc/altivec.h
@@ -1,0 +1,6 @@
+#include_next <altivec.h>
+
+// The altivec headers redefine vector and bool which conflict
+// with C++'s bool type and std::vector. Undefine them here.
+#undef vector
+#undef bool


### PR DESCRIPTION
On the PowerPC family of architectures with Altivec enabled
(ppc, ppc64, ppc64le), one of snes9x's dependencies will
include the altivec.h header which redefines bool and vector.
Since this interferes with the C++ data types of the same
name, they must be undefined to prevent the build from failing.