### PR TITLE
Joystick events send a bogus XWarpPointer event to prevent screensaver

### DIFF
--- a/unix/x11.cpp
+++ b/unix/x11.cpp
@@ -100,6 +100,7 @@ struct GUIData
 	bool8			mod1_pressed;
 	bool8			no_repeat;
 	bool8			fullscreen;
+	bool8			js_event_latch;
 	int				x_offset;
 	int				y_offset;
 #ifdef USE_XVIDEO
@@ -1452,7 +1453,7 @@ static void Repaint (bool8 isFrameBoundry)
 	if (GUI.use_shared_memory)
 	{
 		XShmPutImage(GUI.display, GUI.window, GUI.gc, GUI.image->ximage, 0, 0, GUI.x_offset, GUI.y_offset, SNES_WIDTH * 2, SNES_HEIGHT_EXTENDED * 2, False);
-		XSync(GUI.display, False);
+		XSync(GUI.display, False); // Is this double-sync?  See XQueryPointer below...
 	}
 	else
 #endif
@@ -1511,8 +1512,21 @@ static bool8 CheckForPendingXEvents (Display *display)
 #endif
 }
 
+void S9xLatchJSEvent ()
+{
+	// record that a JS event happened and was reported to the engine
+	GUI.js_event_latch = TRUE;
+}
+
 void S9xProcessEvents (bool8 block)
 {
+	// Kick the screensaver if a joystick event occurred
+	if (GUI.js_event_latch == TRUE) {
+		XWarpPointer(GUI.display, None, None, 0, 0, 0, 0, 0, 0);
+		GUI.js_event_latch = FALSE;
+	}
+
+	// Process all other X events
 	while (block || CheckForPendingXEvents(GUI.display))
 	{
 		XEvent	event;


### PR DESCRIPTION
When SNES9x is running on unix/x11, keypress events and mouse events come to us from the X server.  As part of normal Xevent processing, they also automatically reset the screensaver timeout.  So if you're playing with keyboard or mouse, the screensaver won't ever come on if you keep pushing buttons.

Joystick events do NOT go through the Xevent interface: they are read from /dev/js nodes directly, and the events passed to S9x core via reportbutton() and reportaxis().  This means, if you are playing with just a joypad, after 10 minutes the screensaver comes on - you have to wiggle the mouse or press a key to bring the display back to life.

One solution is to just disable DPMS or the screensaver before launch.  But that's not helpful when my kids just leave the game and walk away :)

This patch adds a new function to x11.cpp called `S9xLatchJSEvent()`, which records internally that "a joystick event occurred since last event processing loop".  Now at the start of `S9xProcessEvents`, if the latch is set, a call to `XWarpPointer()` is made with (0,0) relative coordinates.  This has no actual effect on the mouse position, but **it does reset the screensaver timeout** as though a mouse-move occurred.  It's the closest thing to a dummy / ping / keepalive event that Xevent has.  (And, see [this posting](https://kaffeine-devel.narkive.com/wMRnzQBo/patch-disable-fake-keypresses) for why it's better to use a bogus mouse event than a bogus keypress)

The final piece is that `S9xLatchJSEvent()` is now called from unix.cpp when any joystick event occurs - button change, axis change, plug or unplug.