### PR TITLE
UNIX: fix incorrect YUY2 conversion (GFX_MULTI_FORMAT fallout)

### DIFF
--- a/unix/x11.cpp
+++ b/unix/x11.cpp
@@ -1291,12 +1291,9 @@ void S9xPutImage (int width, int height)
 			for (int x = 0; x < SNES_WIDTH * 2; x += 2)
 			{
 				// Read two RGB pxls
-				//  TODO: there is an assumption of endianness here...
-				// ALSO todo:  The 0x7FFF works around some issue with S9xPutChar, where
-				//  despite asking for RGB555 in InitImage, it insists on drawing with RGB565 instead.
-				//  This may discolor messages but at least it doesn't overflow yuv-tables and crash.
-				unsigned short rgb1 = (*s & 0x7FFF); s++;
-				unsigned short rgb2 = (*s & 0x7FFF); s++;
+				//  Now that we are RGB565 throughout, need to drop the Green LSB
+				unsigned short rgb1 = (*s & 0xFFC0) >> 1 | (*s & 0x001F); s++;
+				unsigned short rgb2 = (*s & 0xFFC0) >> 1 | (*s & 0x001F); s++;
 
 				// put two YUYV pxls
 				// lum1


### PR DESCRIPTION
Removal of GFX_MULTI_FORMAT forces all internal formats to RGB565, however YUY2 conversion still expected RGB555 in some places.  Notably, the color lookup was being built in RGB555 but now referenced in RGB565..

This changes x11.cpp to correctly do YUY2 color lookup based on the RGB555 value, by dropping the LSB of the green component.

Incidentally this fixes an outstanding TODO re: text rendering onto YUY2, where the RGB565 was already assumed internally.  Now it's just assumed everywhere :)