### PR TITLE
Fix GCC unused function/variable warnings

### DIFF
--- a/gtk/src/gtk_s9xwindow.cpp
+++ b/gtk/src/gtk_s9xwindow.cpp
@@ -1534,8 +1534,9 @@ double
 Snes9xWindow::get_refresh_rate ()
 {
     double refresh_rate = 0.0;
+#if defined GDK_WINDOWING_X11 || defined GDK_WINDOWING_WAYLAND
     GdkDisplay *display = gtk_widget_get_display (window);
-    GdkWindow *gdk_window =  gtk_widget_get_window (window);
+#endif
 
 #ifdef GDK_WINDOWING_X11
     if (GDK_IS_X11_DISPLAY (display))
@@ -1549,6 +1550,7 @@ Snes9xWindow::get_refresh_rate ()
 #ifdef GDK_WINDOWING_WAYLAND
     if (GDK_IS_WAYLAND_DISPLAY (display))
     {
+        GdkWindow *gdk_window =  gtk_widget_get_window (window);
         GdkMonitor *monitor = gdk_display_get_monitor_at_window(display, gdk_window);
         refresh_rate = (double) gdk_monitor_get_refresh_rate(monitor) / 1000.0;
     }

--- a/shaders/glsl.cpp
+++ b/shaders/glsl.cpp
@@ -268,6 +268,7 @@ static std::string canonicalize(const std::string &noncanonical)
     return filename_string;
 }
 
+#ifdef USE_SLANG
 static GLuint string_to_format(char *format)
 {
 #define MATCH(s, f)                                                            \
@@ -306,6 +307,7 @@ static GLuint string_to_format(char *format)
 
     return GL_RGBA;
 }
+#endif
 
 // filename must be canonical
 void GLSLShader::read_shader_file_with_includes(std::string filename,


### PR DESCRIPTION
Seen when using GCC 9.2.0.

Warnings fixed:

    [23/105] Compiling C++ object 'snes9x-gtk@exe/.._shaders_glsl.cpp.o'.
    ../shaders/glsl.cpp:271:15: warning: 'GLuint string_to_format(char*)' defined but not used [-Wunused-function]
      271 | static GLuint string_to_format(char *format)
          |               ^~~~~~~~~~~~~~~~
    [49/105] Compiling C++ object 'snes9x-gtk@exe/src_gtk_s9xwindow.cpp.o'.
    ../gtk/src/gtk_s9xwindow.cpp: In member function 'double Snes9xWindow::get_refresh_rate()':
    ../gtk/src/gtk_s9xwindow.cpp:1538:16: warning: unused variable 'gdk_window' [-Wunused-variable]
     1538 |     GdkWindow *gdk_window =  gtk_widget_get_window (window);
          |                ^~~~~~~~~~
