### PR TITLE
CI builds for Linux/FreeBSD/macOS/libretro cores, + binary downloads

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,6 +1,10 @@
 # vim: sts=2 sw=2 ai
 
-linux_task:
+################################################################################
+# snes9x
+################################################################################
+
+snes9x_linux-amd64_task:
   container:
     image: gcc:latest
 
@@ -21,7 +25,7 @@ linux_task:
     path: "snes9x-${CIRRUS_CHANGE_IN_REPO}.txz"
 
 
-macOS_task:
+snes9x_macOS-amd64_task:
   osx_instance:
     image: mojave-xcode
 
@@ -35,4 +39,124 @@ macOS_task:
 
   build_artifacts:
     path: "snes9x-${CIRRUS_CHANGE_IN_REPO}.zip"
+
+################################################################################
+# libretro
+################################################################################
+
+libretro_linux-amd64_task:
+  container:
+    image: gcc:latest
+  compile_script:
+    - make -j2 -C libretro
+  build_artifacts:
+    path: "libretro/snes9x_libretro.so"
+
+
+libretro_linux-i386_task:
+  container:
+    image: dockcross/linux-x86
+  compile_script:
+    - make -j2 -C libretro
+  build_artifacts:
+    path: "libretro/snes9x_libretro.so"
+
+
+libretro_linux-armhf_task:
+  container:
+    image: dockcross/linux-armv7
+  compile_script:
+    - make -j2 -C libretro
+  build_artifacts:
+    path: "libretro/snes9x_libretro.so"
+
+
+libretro_linux-armv7-neon-hf_task:
+  container:
+    image: dockcross/linux-armv7
+  compile_script:
+    - make -j2 -C libretro platform=unix-armv7-neon-hardfloat
+  build_artifacts:
+    path: "libretro/snes9x_libretro.so"
+
+
+libretro_linux-arm64_task:
+  container:
+    image: dockcross/linux-arm64
+  compile_script:
+    - make -j2 -C libretro
+  build_artifacts:
+    path: "libretro/snes9x_libretro.so"
+
+
+libretro_android-arm_task:
+  container:
+    image: dockcross/android-arm
+  compile_script:
+    - make -j2 -C libretro platform=unix
+  build_artifacts:
+    path: "libretro/snes9x_libretro.so"
+
+
+libretro_android-arm64_task:
+  container:
+    image: dockcross/android-arm64
+  compile_script:
+    - make -j2 -C libretro platform=unix-arm64
+  build_artifacts:
+    path: "libretro/snes9x_libretro.so"
+
+
+libretro_emscripten_task:
+  container:
+    image: gcc:latest
+  compile_script:
+    - make -j2 -C libretro platform=emscripten
+  build_artifacts:
+    path: "libretro/snes9x_libretro_emscripten.bc"
+
+
+libretro_macOS-amd64_task:
+  osx_instance:
+    image: mojave-xcode
+  compile_script:
+    - make -j2 -C libretro
+  build_artifacts:
+    path: "libretro/snes9x_libretro.dylib"
+
+
+libretro_nintendo-wii_task:
+  container:
+    image: devkitpro/devkitppc
+  compile_script:
+    - make -j2 -C libretro platform=wii
+  build_artifacts:
+    path: "libretro/snes9x_libretro_wii.a"
+
+
+libretro_nintendo-switch-libnx_task:
+  container:
+    image: devkitpro/devkita64
+  compile_script:
+    - make -j2 -C libretro platform=libnx
+  build_artifacts:
+    path: "libretro/snes9x_libretro_libnx.a"
+
+
+libretro_nintendo-ngc_task:
+  container:
+    image: devkitpro/devkitppc
+  compile_script:
+    - make -j2 -C libretro platform=ngc
+  build_artifacts:
+    path: "libretro/snes9x_libretro_ngc.a"
+
+
+libretro_playstation-psp_task:
+  container:
+    image: bkcsoft/psptoolchain
+  compile_script:
+    - make -j2 -C libretro platform=unix
+  build_artifacts:
+    path: "libretro/snes9x_libretro.so"
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,38 @@
+# vim: sts=2 sw=2 ai
+
+linux_task:
+  container:
+    image: gcc:latest
+
+  setup_script:
+    - git submodule update --init shaders/SPIRV-Cross
+    - apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install meson gettext libsdl2-dev libgtk-3-dev libminizip-dev portaudio19-dev glslang-dev
+
+  compile_script:
+    - meson build gtk --buildtype=release --strip
+    - ninja -j2 -C build
+
+  package_script:
+    - mkdir snes9x
+    - cp -ar build/snes9x-gtk README.md LICENSE docs data gtk/AUTHORS snes9x/
+    - tar -caf "snes9x-${CIRRUS_CHANGE_IN_REPO}.txz" snes9x
+
+  build_artifacts:
+    path: "snes9x-${CIRRUS_CHANGE_IN_REPO}.txz"
+
+
+macOS_task:
+  osx_instance:
+    image: mojave-xcode
+
+  compile_script:
+    - xcodebuild -project macosx/snes9x.xcodeproj -target Snes9x -configuration Release build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
+
+  package_script:
+    - mkdir snes9x
+    - cp -R macosx/build/Release/Snes9x.app macosx/docs README.md LICENSE snes9x/
+    - zip -r "snes9x-${CIRRUS_CHANGE_IN_REPO}.zip" snes9x
+
+  build_artifacts:
+    path: "snes9x-${CIRRUS_CHANGE_IN_REPO}.zip"
+

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,7 +4,7 @@
 # snes9x
 ################################################################################
 
-snes9x_linux-amd64_task:
+snes9x_linux-gtk-amd64_task:
   container:
     image: gcc:latest
 
@@ -19,10 +19,54 @@ snes9x_linux-amd64_task:
   package_script:
     - mkdir snes9x
     - cp -ar build/snes9x-gtk README.md LICENSE docs data gtk/AUTHORS snes9x/
-    - tar -caf "snes9x-${CIRRUS_CHANGE_IN_REPO}.txz" snes9x
+    - tar -caf "snes9x-gtk-${CIRRUS_CHANGE_IN_REPO}.txz" snes9x
 
   build_artifacts:
-    path: "snes9x-${CIRRUS_CHANGE_IN_REPO}.txz"
+    path: "snes9x-gtk-${CIRRUS_CHANGE_IN_REPO}.txz"
+
+
+snes9x_linux-x11-amd64_task:
+  container:
+    image: gcc:latest
+
+  setup_script:
+    - apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install libxv-dev libxinerama-dev
+
+  compile_script:
+    - cd unix
+    - touch configure
+    - ./configure
+    - make -j2
+
+  package_script:
+    - mkdir snes9x
+    - cp -ar unix/snes9x unix/docs unix/snes9x.conf.default README.md LICENSE data snes9x/
+    - tar -caf "snes9x-x11-${CIRRUS_CHANGE_IN_REPO}.txz" snes9x
+
+  build_artifacts:
+    path: "snes9x-x11-${CIRRUS_CHANGE_IN_REPO}.txz"
+
+
+snes9x_freebsd-x11-amd64_task:
+  freebsd_instance:
+    image: freebsd-12-1-release-amd64
+
+  setup_script:
+    - pkg install -y gmake pkgconf minizip libX11 libXext
+
+  compile_script:
+    - cd unix
+    - touch configure
+    - ./configure
+    - gmake -j2
+
+  package_script:
+    - mkdir snes9x
+    - cp -a unix/snes9x unix/docs unix/snes9x.conf.default README.md LICENSE data snes9x/
+    - tar -caf "snes9x-x11-${CIRRUS_CHANGE_IN_REPO}.txz" snes9x
+
+  build_artifacts:
+    path: "snes9x-x11-${CIRRUS_CHANGE_IN_REPO}.txz"
 
 
 snes9x_macOS-amd64_task:

--- a/.gitignore
+++ b/.gitignore
@@ -495,3 +495,7 @@ healthchecksdb
 MigrationBackup/
 
 # End of https://www.gitignore.io/api/c,c++,xcode,visualstudio
+
+# vim
+*.swp
+

--- a/README.md
+++ b/README.md
@@ -11,17 +11,21 @@ Download nightly builds from continuous integration:
 
 ### snes9x
 
-| OS      | status                                     |
-|---------|--------------------------------------------|
-| Windows | [![Status][s9x-win-all]][appveyor]        |
-| Linux   | [![Status][snes9x_linux-amd64]][cirrus-ci] |
-| macOS   | [![Status][snes9x_macOS-amd64]][cirrus-ci] |
+| OS            | status                                           |
+|---------------|--------------------------------------------------|
+| Windows       | [![Status][s9x-win-all]][appveyor]               |
+| Linux (GTK)   | [![Status][snes9x_linux-gtk-amd64]][cirrus-ci]   |
+| Linux (X11)   | [![Status][snes9x_linux-x11-amd64]][cirrus-ci]   |
+| FreeBSD (X11) | [![Status][snes9x_freebsd-x11-amd64]][cirrus-ci] |
+| macOS         | [![Status][snes9x_macOS-amd64]][cirrus-ci]       |
 
 [appveyor]: https://ci.appveyor.com/project/snes9x/snes9x
 [cirrus-ci]: http://cirrus-ci.com/github/snes9xgit/snes9x
 
 [s9x-win-all]: https://ci.appveyor.com/api/projects/status/github/snes9xgit/snes9x?branch=master&svg=true
-[snes9x_linux-amd64]: https://api.cirrus-ci.com/github/snes9xgit/snes9x.svg?task=snes9x_linux-amd64
+[snes9x_linux-gtk-amd64]: https://api.cirrus-ci.com/github/snes9xgit/snes9x.svg?task=snes9x_linux-gtk-amd64
+[snes9x_linux-x11-amd64]: https://api.cirrus-ci.com/github/snes9xgit/snes9x.svg?task=snes9x_linux-x11-amd64
+[snes9x_freebsd-x11-amd64]: https://api.cirrus-ci.com/github/snes9xgit/snes9x.svg?task=snes9x_freebsd-x11-amd64
 [snes9x_macOS-amd64]: https://api.cirrus-ci.com/github/snes9xgit/snes9x.svg?task=snes9x_macOS-amd64
 
 ### libretro core

--- a/README.md
+++ b/README.md
@@ -9,7 +9,49 @@ Please check the [Wiki](https://github.com/snes9xgit/snes9x/wiki) for additional
 
 Download nightly builds from continuous integration:
 
-[![Build Status](https://api.cirrus-ci.com/github/snes9xgit/snes9x.svg?task=linux)](https://cirrus-ci.com/github/snes9xgit/snes9x)
-[![Build Status](https://api.cirrus-ci.com/github/snes9xgit/snes9x.svg?task=macOS)](https://cirrus-ci.com/github/snes9xgit/snes9x)
-[![Build Status](https://ci.appveyor.com/api/projects/status/github/snes9xgit/snes9x?branch=master&svg=true)](https://ci.appveyor.com/project/snes9x/snes9x)
+### snes9x
 
+| OS      | status                                     |
+|---------|--------------------------------------------|
+| Windows | [![Status][s9x-win-all]][appveyor]        |
+| Linux   | [![Status][snes9x_linux-amd64]][cirrus-ci] |
+| macOS   | [![Status][snes9x_macOS-amd64]][cirrus-ci] |
+
+[appveyor]: https://ci.appveyor.com/project/snes9x/snes9x
+[cirrus-ci]: http://cirrus-ci.com/github/snes9xgit/snes9x
+
+[s9x-win-all]: https://ci.appveyor.com/api/projects/status/github/snes9xgit/snes9x?branch=master&svg=true
+[snes9x_linux-amd64]: https://api.cirrus-ci.com/github/snes9xgit/snes9x.svg?task=snes9x_linux-amd64
+[snes9x_macOS-amd64]: https://api.cirrus-ci.com/github/snes9xgit/snes9x.svg?task=snes9x_macOS-amd64
+
+### libretro core
+
+| OS                  | status                                                  |
+|---------------------|---------------------------------------------------------|
+| Linux/amd64         | [![Status][libretro_linux-amd64]][cirrus-ci]            |
+| Linux/i386          | [![Status][libretro_linux-i386]][cirrus-ci]             |
+| Linux/armhf         | [![Status][libretro_linux-armhf]][cirrus-ci]            |
+| Linux/armv7-neon-hf | [![Status][libretro_linux-armv7-neon-hf]][cirrus-ci]    |
+| Linux/arm64         | [![Status][libretro_linux-arm64]][cirrus-ci]            |
+| Android/arm         | [![Status][libretro_android-arm]][cirrus-ci]            |
+| Android/arm64       | [![Status][libretro_android-arm64]][cirrus-ci]          |
+| Emscripten          | [![Status][libretro_emscripten]][cirrus-ci]             |
+| macOS/amd64         | [![Status][libretro_macOS-amd64]][cirrus-ci]            |
+| Nintendo Wii        | [![Status][libretro_nintendo-wii]][cirrus-ci]           |
+| Nintendo Switch     | [![Status][libretro_nintendo-switch-libnx]][cirrus-ci]  |
+| Nintendo GameCube   | [![Status][libretro_nintendo-ngc]][cirrus-ci]           |
+| PSP                 | [![Status][libretro_playstation-psp]][cirrus-ci]        |
+
+[libretro_linux-amd64]: https://api.cirrus-ci.com/github/snes9xgit/snes9x.svg?task=libretro_linux-amd64
+[libretro_linux-i386]: https://api.cirrus-ci.com/github/snes9xgit/snes9x.svg?task=libretro_linux-i386
+[libretro_linux-armhf]: https://api.cirrus-ci.com/github/snes9xgit/snes9x.svg?task=libretro_linux-armhf
+[libretro_linux-armv7-neon-hf]: https://api.cirrus-ci.com/github/snes9xgit/snes9x.svg?task=libretro_linux-armv7-neon-hf
+[libretro_linux-arm64]: https://api.cirrus-ci.com/github/snes9xgit/snes9x.svg?task=libretro_linux-arm64
+[libretro_android-arm]: https://api.cirrus-ci.com/github/snes9xgit/snes9x.svg?task=libretro_android-arm
+[libretro_android-arm64]: https://api.cirrus-ci.com/github/snes9xgit/snes9x.svg?task=libretro_android-arm64
+[libretro_emscripten]: https://api.cirrus-ci.com/github/snes9xgit/snes9x.svg?task=libretro_emscripten
+[libretro_macOS-amd64]: https://api.cirrus-ci.com/github/snes9xgit/snes9x.svg?task=libretro_macOS-amd64
+[libretro_nintendo-wii]: https://api.cirrus-ci.com/github/snes9xgit/snes9x.svg?task=libretro_nintendo-wii
+[libretro_nintendo-switch-libnx]: https://api.cirrus-ci.com/github/snes9xgit/snes9x.svg?task=libretro_nintendo-switch-libnx
+[libretro_nintendo-ngc]: https://api.cirrus-ci.com/github/snes9xgit/snes9x.svg?task=libretro_nintendo-ngc
+[libretro_playstation-psp]: https://api.cirrus-ci.com/github/snes9xgit/snes9x.svg?task=libretro_playstation-psp

--- a/README.md
+++ b/README.md
@@ -4,3 +4,12 @@
 This is the official source code repository for the Snes9x project.
 
 Please check the [Wiki](https://github.com/snes9xgit/snes9x/wiki) for additional information.
+
+## Nightly builds
+
+Download nightly builds from continuous integration:
+
+[![Build Status](https://api.cirrus-ci.com/github/snes9xgit/snes9x.svg?task=linux)](https://cirrus-ci.com/github/snes9xgit/snes9x)
+[![Build Status](https://api.cirrus-ci.com/github/snes9xgit/snes9x.svg?task=macOS)](https://cirrus-ci.com/github/snes9xgit/snes9x)
+[![Build Status](https://ci.appveyor.com/api/projects/status/github/snes9xgit/snes9x?branch=master&svg=true)](https://ci.appveyor.com/project/snes9x/snes9x)
+

--- a/gtk/meson.build
+++ b/gtk/meson.build
@@ -93,13 +93,14 @@ endif
 
 if slang and opengl
   glslang_dep = c_compiler.find_library('glslang', required: false)
+  hlsl_dep = c_compiler.find_library('HLSL', required: false)
   spirv_dep = c_compiler.find_library('SPIRV', required: false)
   osdependent_dep = c_compiler.find_library('OSDependent', required: false)
   ogl_compiler_dep = c_compiler.find_library('OGLCompiler', required: false)
   spv_remapper_dep = c_compiler.find_library('SPVRemapper', required: false)
 
-  if glslang_dep.found() and spirv_dep.found() and osdependent_dep.found() and ogl_compiler_dep.found() and spv_remapper_dep.found()
-    deps += [glslang_dep, spirv_dep, osdependent_dep, ogl_compiler_dep, spv_remapper_dep]
+  if glslang_dep.found() and hlsl_dep.found() and spirv_dep.found() and osdependent_dep.found() and ogl_compiler_dep.found() and spv_remapper_dep.found()
+    deps += [glslang_dep, hlsl_dep, spirv_dep, osdependent_dep, ogl_compiler_dep, spv_remapper_dep]
 
     args += ['-DUSE_SLANG',
              '-DSPIRV_CROSS_EXCEPTIONS_TO_ASSERTIONS',


### PR DESCRIPTION
I noticed there are no Linux downloads currently, and Linux/macOS/numerous `libretro` builds do not seem to be being tested. This PR attempts to fix that.

Here's an example of a test run: https://cirrus-ci.com/build/5710368030064640

(Please be aware that the build status badges on my GitHub repo lead to your currently non-existent CI page, and that's the reason they are listed as "unknown".)

Binary artifacts (`snes9x`/`libretro` cores) for each target are available from the appropriate task's page. The README file has been updated to direct lazy users (like myself) to them.

`libretro` tasks were mostly adapted from #599, which doesn't seem to be active anymore.

I couldn't build the project with `glslang` stuff enabled on Debian 10 and Ubuntu 19.10/18.04; it was failing with the following linker error:

    [1/1] Linking target snes9x-gtk.
    FAILED: snes9x-gtk
    c++  -o snes9x-gtk 'snes9x-gtk@exe/meson-generated_.._gtk_snes9x_ui.cpp.o' 'snes9x-gtk@exe/src_gtk_display_driver_opengl.cpp.o' 'snes9x-gtk@exe/src_gtk_glx_context.cpp.o' 'snes9x-gtk@exe/.._shaders_glsl.cpp.o' 'snes9x-gtk@exe/.._shaders_shader_helpers.cpp.o' 'snes9x-gtk@exe/src_gtk_shader_parameters.cpp.o' 'snes9x-gtk@exe/.._shaders_slang.cpp.o' 'snes9x-gtk@exe/.._shaders_SPIRV-Cross_spirv_cfg.cpp.o' 'snes9x-gtk@exe/.._shaders_SPIRV-Cross_spirv_cross.cpp.o' 'snes9x-gtk@exe/.._shaders_SPIRV-Cross_spirv_glsl.cpp.o' 'snes9x-gtk@exe/.._shaders_SPIRV-Cross_spirv_cross_parsed_ir.cpp.o' 'snes9x-gtk@exe/.._shaders_SPIRV-Cross_spirv_parser.cpp.o' 'snes9x-gtk@exe/src_gtk_wayland_egl_context.cpp.o' 'snes9x-gtk@exe/src_gtk_display_driver_xv.cpp.o' 'snes9x-gtk@exe/src_gtk_sound_driver_portaudio.cpp.o' 'snes9x-gtk@exe/src_gtk_sound_driver_oss.cpp.o' 'snes9x-gtk@exe/src_gtk_sound_driver_alsa.cpp.o' 'snes9x-gtk@exe/src_gtk_sound_driver_pulse.cpp.o' 'snes9x-gtk@exe/.._filter_hq2x.cpp.o' 'snes9x-gtk@exe/.._filter_xbrz.cpp.o' 'snes9x-gtk@exe/src_filter_xbrz.cpp.o' 'snes9x-gtk@exe/.._filter_2xsai.cpp.o' 'snes9x-gtk@exe/.._filter_epx.cpp.o' 'snes9x-gtk@exe/src_filter_epx_unsafe.cpp.o' 'snes9x-gtk@exe/src_gtk_binding.cpp.o' 'snes9x-gtk@exe/src_gtk_cheat.cpp.o' 'snes9x-gtk@exe/src_gtk_config.cpp.o' 'snes9x-gtk@exe/src_gtk_control.cpp.o' 'snes9x-gtk@exe/src_gtk_display.cpp.o' 'snes9x-gtk@exe/src_gtk_display_driver_gtk.cpp.o' 'snes9x-gtk@exe/src_gtk_file.cpp.o' 'snes9x-gtk@exe/src_gtk_builder_window.cpp.o' 'snes9x-gtk@exe/src_gtk_preferences.cpp.o' 'snes9x-gtk@exe/src_gtk_s9x.cpp.o' 'snes9x-gtk@exe/src_gtk_s9xwindow.cpp.o' 'snes9x-gtk@exe/src_gtk_sound.cpp.o' 'snes9x-gtk@exe/src_gtk_splash.cpp.o' 'snes9x-gtk@exe/.._filter_snes_ntsc.c.o' 'snes9x-gtk@exe/src_gtk_sound_driver_sdl.cpp.o' 'snes9x-gtk@exe/.._fxinst.cpp.o' 'snes9x-gtk@exe/.._fxemu.cpp.o' 'snes9x-gtk@exe/.._fxdbg.cpp.o' 'snes9x-gtk@exe/.._c4.cpp.o' 'snes9x-gtk@exe/.._c4emu.cpp.o' 'snes9x-gtk@exe/.._apu_apu.cpp.o' 'snes9x-gtk@exe/.._apu_bapu_dsp_sdsp.cpp.o' 'snes9x-gtk@exe/.._apu_bapu_smp_smp.cpp.o' 'snes9x-gtk@exe/.._apu_bapu_smp_smp_state.cpp.o' 'snes9x-gtk@exe/.._msu1.cpp.o' 'snes9x-gtk@exe/.._dsp.cpp.o' 'snes9x-gtk@exe/.._dsp1.cpp.o' 'snes9x-gtk@exe/.._dsp2.cpp.o' 'snes9x-gtk@exe/.._dsp3.cpp.o' 'snes9x-gtk@exe/.._dsp4.cpp.o' 'snes9x-gtk@exe/.._spc7110.cpp.o' 'snes9x-gtk@exe/.._obc1.cpp.o' 'snes9x-gtk@exe/.._seta.cpp.o' 'snes9x-gtk@exe/.._seta010.cpp.o' 'snes9x-gtk@exe/.._seta011.cpp.o' 'snes9x-gtk@exe/.._seta018.cpp.o' 'snes9x-gtk@exe/.._controls.cpp.o' 'snes9x-gtk@exe/.._crosshairs.cpp.o' 'snes9x-gtk@exe/.._cpu.cpp.o' 'snes9x-gtk@exe/.._sa1.cpp.o' 'snes9x-gtk@exe/.._debug.cpp.o' 'snes9x-gtk@exe/.._sdd1.cpp.o' 'snes9x-gtk@exe/.._tile.cpp.o' 'snes9x-gtk@exe/.._tileimpl-n1x1.cpp.o' 'snes9x-gtk@exe/.._tileimpl-n2x1.cpp.o' 'snes9x-gtk@exe/.._tileimpl-h2x1.cpp.o' 'snes9x-gtk@exe/.._srtc.cpp.o' 'snes9x-gtk@exe/.._gfx.cpp.o' 'snes9x-gtk@exe/.._memmap.cpp.o' 'snes9x-gtk@exe/.._clip.cpp.o' 'snes9x-gtk@exe/.._ppu.cpp.o' 'snes9x-gtk@exe/.._dma.cpp.o' 'snes9x-gtk@exe/.._snes9x.cpp.o' 'snes9x-gtk@exe/.._globals.cpp.o' 'snes9x-gtk@exe/.._stream.cpp.o' 'snes9x-gtk@exe/.._conffile.cpp.o' 'snes9x-gtk@exe/.._bsx.cpp.o' 'snes9x-gtk@exe/.._logger.cpp.o' 'snes9x-gtk@exe/.._snapshot.cpp.o' 'snes9x-gtk@exe/.._screenshot.cpp.o' 'snes9x-gtk@exe/.._movie.cpp.o' 'snes9x-gtk@exe/.._statemanager.cpp.o' 'snes9x-gtk@exe/.._sha256.cpp.o' 'snes9x-gtk@exe/.._bml.cpp.o' 'snes9x-gtk@exe/.._cpuops.cpp.o' 'snes9x-gtk@exe/.._cpuexec.cpp.o' 'snes9x-gtk@exe/.._sa1cpu.cpp.o' 'snes9x-gtk@exe/.._cheats.cpp.o' 'snes9x-gtk@exe/.._cheats2.cpp.o' 'snes9x-gtk@exe/.._sdd1emu.cpp.o' 'snes9x-gtk@exe/.._netplay.cpp.o' 'snes9x-gtk@exe/.._server.cpp.o' 'snes9x-gtk@exe/.._loadzip.cpp.o' 'snes9x-gtk@exe/src_gtk_netplay_dialog.cpp.o' 'snes9x-gtk@exe/src_gtk_netplay.cpp.o' 'snes9x-gtk@exe/src_background_particles.cpp.o' -Wl,--no-undefined -Wl,--as-needed -Wl,-O1 -Wl,--start-group libjma.a /usr/lib/x86_64-linux-gnu/libglib-2.0.so /usr/lib/x86_64-linux-gnu/libgthread-2.0.so -pthread /usr/lib/x86_64-linux-gnu/libgobject-2.0.so /usr/lib/x86_64-linux-gnu/libSDL2.so /usr/lib/x86_64-linux-gnu/libgtk-3.so /usr/lib/x86_64-linux-gnu/libgdk-3.so /usr/lib/x86_64-linux-gnu/libpangocairo-1.0.so /usr/lib/x86_64-linux-gnu/libpango-1.0.so /usr/lib/x86_64-linux-gnu/libatk-1.0.so /usr/lib/x86_64-linux-gnu/libcairo-gobject.so /usr/lib/x86_64-linux-gnu/libcairo.so /usr/lib/x86_64-linux-gnu/libgdk_pixbuf-2.0.so /usr/lib/x86_64-linux-gnu/libgio-2.0.so -lX11 -lXext -ldl /usr/lib/x86_64-linux-gnu/libXrandr.so /usr/lib/x86_64-linux-gnu/libepoxy.so -lglslang -lSPIRV -lOSDependent -lOGLCompiler -lSPVRemapper /usr/lib/x86_64-linux-gnu/libwayland-egl.so /usr/lib/x86_64-linux-gnu/libwayland-client.so /usr/lib/x86_64-linux-gnu/libXv.so /usr/lib/x86_64-linux-gnu/libportaudio.so /usr/lib/x86_64-linux-gnu/libasound.so -lm -lpthread /usr/lib/x86_64-linux-gnu/libpulse.so /usr/lib/x86_64-linux-gnu/libpng16.so /usr/lib/x86_64-linux-gnu/libz.so /usr/lib/x86_64-linux-gnu/libminizip.so -Wl,--end-group '-Wl,-rpath,$ORIGIN/' -Wl,-rpath-link,/snes-hg/build/
    /usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/8/../../../x86_64-linux-gnu/libglslang.a(ShaderLang.cpp.o): in function `ShInitialize':
    (.text+0x1e99): undefined reference to `glslang::HlslScanContext::fillInKeywordMap()'
    /usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/8/../../../x86_64-linux-gnu/libglslang.a(ShaderLang.cpp.o): in function `ShFinalize':
    (.text+0x22d0): undefined reference to `glslang::HlslScanContext::deleteKeywordMap()'
    /usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/8/../../../x86_64-linux-gnu/libglslang.a(ShaderLang.cpp.o): in function `(anonymous namespace)::CreateParseContext(glslang::TSymbolTable&, glslang::TIntermediate&, int, EProfile, glslang::EShSource, EShLanguage, TInfoSink&, glslang::SpvVersion, bool, EShMessages, bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >)':
    (.text+0x6612): undefined reference to `glslang::HlslParseContext::HlslParseContext(glslang::TSymbolTable&, glslang::TIntermediate&, bool, int, EProfile, glslang::SpvVersion const&, EShLanguage, TInfoSink&, std::__cxx11::basic_string<char, std::char_traits<char>, glslang::pool_allocator<char> >, bool, EShMessages)'
    /usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/8/../../../x86_64-linux-gnu/libglslang.a(ShaderLang.cpp.o): in function `(anonymous namespace)::SetupBuiltinSymbolTable(int, EProfile, glslang::SpvVersion const&, glslang::EShSource)':
    (.text+0x81d4): undefined reference to `glslang::TBuiltInParseablesHlsl::TBuiltInParseablesHlsl()'
    /usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/8/../../../x86_64-linux-gnu/libglslang.a(ShaderLang.cpp.o): in function `(anonymous namespace)::AddContextSpecificSymbols(TBuiltInResource const*, TInfoSink&, glslang::TSymbolTable&, int, EProfile, glslang::SpvVersion const&, EShLanguage, glslang::EShSource)':
    (.text+0x8dc9): undefined reference to `glslang::TBuiltInParseablesHlsl::TBuiltInParseablesHlsl()'
    collect2: error: ld returned 1 exit status
    ninja: build stopped: subcommand failed.

This PR attempts to fix this too. Please let me know if you want me to take it out, or move it into a separate PR.

Note: `ninja -j2` is being used due to it sometimes failing with OOM errors if left on default settings (which resulted in 4 jobs being run in parallel.)

Why did I have to pull in another CI service?

1. `appveyor.yml` is already pretty complicated, and this adds at least as much stuff as is already in there.
1. Cirrus is pretty damn fast in my experience, it takes 1-2 minutes to build all the targets, except for macOS ones (they sometimes take longer due to lower limits.)
1. And I had the excellent `bsnes` [example](https://github.com/byuu/bsnes/blob/master/.cirrus.yml) to work from.

Should you decide to merge this, you'll need to enable Cirrus CI for this repository.

1. Visit https://cirrus-ci.com/
1. Sign in with your GitHub account.
1. Visit https://github.com/marketplace/cirrus-ci , select the free CI plan, and give it access to this repository.
