### PR TITLE
Fix Visual Studio 2019 (C3848 error in conffile.cpp)

### DIFF
--- a/conffile.cpp
+++ b/conffile.cpp
@@ -452,7 +452,7 @@ void ConfigFile::ClearLines()
     }
 }
 
-bool ConfigFile::ConfigEntry::section_then_key_less::operator()(const ConfigEntry &a, const ConfigEntry &b) {
+bool ConfigFile::ConfigEntry::section_then_key_less::operator()(const ConfigEntry &a, const ConfigEntry &b) const{
 	if(curConfigFile && a.section!=b.section){
 		const int sva = curConfigFile->GetSectionSize(a.section);
 		const int svb = curConfigFile->GetSectionSize(b.section);

--- a/conffile.h
+++ b/conffile.h
@@ -90,7 +90,7 @@ class ConfigFile {
 		mutable bool used;
 
         struct section_then_key_less {
-            bool operator()(const ConfigEntry &a, const ConfigEntry &b);
+            bool operator()(const ConfigEntry &a, const ConfigEntry &b) const;
         };
 
         struct key_less {
@@ -101,8 +101,8 @@ class ConfigFile {
         };
 
         struct line_less {
-            bool operator()(const ConfigEntry &a, const ConfigEntry &b){
-				if(a.line==b.line) return (b.val.empty() && !a.val.empty()) || a.key<b.key;
+            bool operator()(const ConfigEntry &a, const ConfigEntry &b) const{
+                if(a.line==b.line) return (b.val.empty() && !a.val.empty()) || a.key<b.key;
                 if(b.line<0) return true;
                 if(a.line<0) return false;
                 return a.line<b.line;


### PR DESCRIPTION
This Pull Request will fix the build with Visual Studio 2019.

```
8>C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.24.28314\include\xutility(1481): error C3848: 型 'const ConfigFile::ConfigEntry::section_then_key_less' を含む式は、'bool ConfigFile::ConfigEntry::section_then_key_less::operator ()(const ConfigFile::ConfigEntry &,const ConfigFile::ConfigEntry &)' を呼び出すためにいくつかの const volatile 修飾子を失う可能性があります。
```
