### PR TITLE
[appveyor] Fix "git: No tags can describe xxx" error caused in forked repositories

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,8 +43,7 @@ build_script:
   - if "%config%"=="libretro Release" msbuild libretro\libretro-win32.vcxproj /t:build /p:Configuration="%config%";Platform="%platform%" /m /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
 
 after_build:
-  - ps: $env:gitrev = git describe --tags
-  - ps: $env:my_version = "$env:gitrev"
+  - ps: $env:my_version = "$env:APPVEYOR_BUILD_VERSION-$($env:APPVEYOR_REPO_COMMIT.substring(0,7))"
   - set package_name=snes9x-%my_version%-%arch%
   - if exist artifacts rmdir /s /q artifacts
   - mkdir artifacts


### PR DESCRIPTION
The `git describe --tags` command in appveyor.yml will cause a "git : fatal: No tags can describe" error in a forked repository if there are no appropriate tags. That command is just used to build the filename of the artifact.

This PR removes the command from appveyor.yml and uses some [predefined environment variables](https://www.appveyor.com/docs/environment-variables/) instead.