### PR TITLE
Increase SRAM size to 512KB

### DIFF
--- a/memmap.cpp
+++ b/memmap.cpp
@@ -894,7 +894,7 @@ static void S9xDeinterleaveGD24 (int size, uint8 *base)
 bool8 CMemory::Init (void)
 {
     RAM	 = (uint8 *) malloc(0x20000);
-    SRAM = (uint8 *) malloc(0x20000);
+    SRAM = (uint8 *) malloc(0x80000);
     VRAM = (uint8 *) malloc(0x10000);
     ROM  = (uint8 *) malloc(MAX_ROM_SIZE + 0x200 + 0x8000);
 
@@ -935,7 +935,7 @@ bool8 CMemory::Init (void)
     }
 
 	memset(RAM, 0,  0x20000);
-	memset(SRAM, 0, 0x20000);
+	memset(SRAM, 0, 0x80000);
 	memset(VRAM, 0, 0x10000);
 	memset(ROM, 0,  MAX_ROM_SIZE + 0x200 + 0x8000);
 

--- a/snapshot.cpp
+++ b/snapshot.cpp
@@ -1199,7 +1199,7 @@ void S9xFreezeToStream (STREAM stream)
 
 	FreezeBlock (stream, "RAM", Memory.RAM, 0x20000);
 
-	FreezeBlock (stream, "SRA", Memory.SRAM, 0x20000);
+	FreezeBlock (stream, "SRA", Memory.SRAM, 0x80000);
 
 	FreezeBlock (stream, "FIL", Memory.FillRAM, 0x8000);
 
@@ -1404,9 +1404,9 @@ int S9xUnfreezeFromStream (STREAM stream)
 			break;
 
 		if (fast)
-			result = UnfreezeBlock(stream, "SRA", Memory.SRAM, 0x20000);
+			result = UnfreezeBlock(stream, "SRA", Memory.SRAM, 0x80000);
 		else
-			result = UnfreezeBlockCopy (stream, "SRA", &local_sram, 0x20000);
+			result = UnfreezeBlockCopy (stream, "SRA", &local_sram, 0x80000);
 		if (result != SUCCESS)
 			break;
 
@@ -1576,7 +1576,7 @@ int S9xUnfreezeFromStream (STREAM stream)
 			memcpy(Memory.RAM, local_ram, 0x20000);
 
 		if (local_sram)
-			memcpy(Memory.SRAM, local_sram, 0x20000);
+			memcpy(Memory.SRAM, local_sram, 0x80000);
 
 		if (local_fillram)
 			memcpy(Memory.FillRAM, local_fillram, 0x8000);


### PR DESCRIPTION
Increased SRAM size from 128KB to 512KB.  This fixes a crash in the
emulator when writing to SRAM between addresses $720000 and $7DFFFF.

Fixes #637 