### PR TITLE
Indicate required Meson version

### DIFF
--- a/gtk/meson.build
+++ b/gtk/meson.build
@@ -1,6 +1,7 @@
 project('snes9x-gtk',
         ['c', 'cpp'],
         version: '1.60',
+        meson_version: '>=0.46.0',
         default_options: ['cpp_std=c++14'])
 
 args = ['-DSNES9X_GTK', '-DUNZIP_SUPPORT', '-DNETPLAY_SUPPORT', '-DJMA_SUPPORT', '-Wall', '-W', '-Wno-unused-parameter']


### PR DESCRIPTION
Inspired by issue #613, it would probably be helpful for users to know that their version of Meson is too old rather than being bombarded by error messages that they might not understand.