### PR TITLE
Fixed support of MSU-1 audio files on MacOS.

### DIFF
--- a/macosx/mac-file.mm
+++ b/macosx/mac-file.mm
@@ -295,13 +295,17 @@ const char * S9xGetFilename (const char *inExt, enum s9x_getdirtype dirtype)
 		else
 		{
 			_splitpath(Memory.ROMFilename, drive, dir, fname, ext);
-			_makepath(filePath[index], drive, dir, fname, inExt);
+
+			strcat(fname, inExt);
+			_makepath(filePath[index], drive, dir, fname, "");
 		}
 	}
 	else
 	{
 		_splitpath(Memory.ROMFilename, drive, dir, fname, ext);
-		_makepath(filePath[index], drive, dir, fname, inExt);
+
+		strcat(fname, inExt);
+		_makepath(filePath[index], drive, dir, fname, "");
 	}
 
 	return (filePath[index]);


### PR DESCRIPTION
Adjusted how MacOS specific implementation of S9xMSU1OpenFile builds up paths when calling _makepath to allow for enumeration suffixes (e.g. -1.pcm).