### PR TITLE
Add alsa sound output and I420 Xvideo image format support for unix CLI.

### DIFF
--- a/unix/configure.ac
+++ b/unix/configure.ac
@@ -445,6 +445,22 @@ if test "x$enable_xvideo" = "xyes"; then
 	])
 fi
 
+# Check if we can build with libyuv hardware acceleration I420 conversion support
+AC_ARG_ENABLE([libyuv],
+    [AS_HELP_STRING([--enable-libyuv],
+        [enable libyuv I420 conversion support if available (default: yes)])],
+    [], [enable_libyuv="yes"])
+
+if test "x$enable_libyuv" = "xyes"; then
+    enable_libyuv="no"
+    AC_CHECK_HEADER([libyuv.h],
+    [
+        enable_libyuv="yes"
+        S9XLIBS="$S9XLIBS -lyuv"
+        S9XDEFS="$S9XDEFS -DUSE_LIBYUV"
+    ])
+fi
+
 # Check if we can build with Xinerama multi-monitor support
 AC_ARG_ENABLE([xinerama],
 	[AS_HELP_STRING([--enable-xinerama],
@@ -545,6 +561,7 @@ libs................. $S9XLIBS
 
 features:
 Xvideo support....... $enable_xvideo
+libyuv support....... $enable_libyuv
 Xinerama support..... $enable_xinerama
 sound support........ $enable_sound
 alsa support......... $enable_sound_alsa

--- a/unix/configure.ac
+++ b/unix/configure.ac
@@ -489,6 +489,25 @@ else
 	S9XDEFS="$S9XDEFS -DNOSOUND"
 fi
 
+# Check if we can build with alsa support
+AC_ARG_ENABLE([sound-alsa],
+    [AS_HELP_STRING([--enable-sound-alsa],
+        [enable Alsa if available (default: yes)])],
+    [], [enable_sound_alsa="yes"])
+
+if test "x$enable_sound_alsa" = "xyes"; then
+    enable_sound_alsa="no"
+    AC_CHECK_HEADER([alsa/asoundlib.h],
+    [
+        enable_sound_alsa="yes"
+        enable_sound="yes"
+        S9XLIBS="$S9XLIBS -lasound"
+        #in case '--disable-sound' and 'enable-sound-alsa'
+        S9XDEFS=$(echo $S9XDEFS|sed 's/-DNOSOUND//g; s/-DUSE_THREADS//g')
+        S9XDEFS="$S9XDEFS -DALSA"
+    ])
+fi
+
 # Output.
 
 S9XFLGS="$CXXFLAGS $CPPFLAGS $LDFLAGS $S9XFLGS"
@@ -528,6 +547,7 @@ features:
 Xvideo support....... $enable_xvideo
 Xinerama support..... $enable_xinerama
 sound support........ $enable_sound
+alsa support......... $enable_sound_alsa
 screenshot support... $enable_screenshot
 netplay support...... $enable_netplay
 gamepad support...... $enable_gamepad

--- a/unix/unix.cpp
+++ b/unix/unix.cpp
@@ -338,9 +338,13 @@ void S9xExtraUsage (void)
 #ifdef JOYSTICK_SUPPORT
 	S9xMessage(S9X_INFO, S9X_USAGE, "-nogamepad                      Disable gamepad reading");
 	S9xMessage(S9X_INFO, S9X_USAGE, "-paddev1 <string>               Specify gamepad device 1");
-	S9xMessage(S9X_INFO, S9X_USAGE, "-paddev1 <string>               Specify gamepad device 2");
-	S9xMessage(S9X_INFO, S9X_USAGE, "-paddev1 <string>               Specify gamepad device 3");
-	S9xMessage(S9X_INFO, S9X_USAGE, "-paddev1 <string>               Specify gamepad device 4");
+	S9xMessage(S9X_INFO, S9X_USAGE, "-paddev2 <string>               Specify gamepad device 2");
+	S9xMessage(S9X_INFO, S9X_USAGE, "-paddev3 <string>               Specify gamepad device 3");
+	S9xMessage(S9X_INFO, S9X_USAGE, "-paddev4 <string>               Specify gamepad device 4");
+	S9xMessage(S9X_INFO, S9X_USAGE, "-paddev5 <string>               Specify gamepad device 5");
+	S9xMessage(S9X_INFO, S9X_USAGE, "-paddev6 <string>               Specify gamepad device 6");
+	S9xMessage(S9X_INFO, S9X_USAGE, "-paddev7 <string>               Specify gamepad device 7");
+	S9xMessage(S9X_INFO, S9X_USAGE, "-paddev8 <string>               Specify gamepad device 8");
 	S9xMessage(S9X_INFO, S9X_USAGE, "");
 #endif
 

--- a/unix/unix.cpp
+++ b/unix/unix.cpp
@@ -1416,10 +1416,11 @@ void S9xSamplesAvailable(void *data)
     }
 #endif
 
-    S9xMixSamples(sound_buffer, samples_to_write);
 #ifndef ALSA
+    S9xMixSamples(sound_buffer, samples_to_write);
     s_AudioOutput->Write(sound_buffer, samples_to_write * 2);
 #else
+    S9xMixSamples(sound_buffer, frames*2);
     frames_written = 0;
 
     while (frames_written < frames) {


### PR DESCRIPTION
this pull request includes: 

1. Fix paddevN args mistakes.

2. Add alsa sound output support and configuration param. OSS support is still OK, althouth I really do not like too many 'ifdef':-)

3. Add I420 xvideo image format support with software and libyuv hardware acceleration conversion. modern Linux dist with modesettings and glamor can only support planar YUV formats such as 'I420'. snes9x CLI xvideo acceleration and fullscreen scale will not work without this.