### PR TITLE
fix custom key bind for frame advance

### DIFF
--- a/win32/wsnes9x.cpp
+++ b/win32/wsnes9x.cpp
@@ -8613,7 +8613,7 @@ switch(msg)
 			break;
 		}
 
-        if(which >= IDC_HOTKEY1 && which <= IDC_HOTKEY13)
+        if(which >= IDC_HOTKEY1 && which <= IDC_HOTKEY14)
         {
             int offset = which - IDC_HOTKEY1;
             hotkey_dialog_items[index][offset].key_entry->key = wParam;


### PR DESCRIPTION
Clicking on the Frame Advance field in the Customize Hotkeys dialog would highlight the field, but no key combination (including Escape to disable it) would actually change the value.