### PR TITLE
libretro: Fix 4:3 aspect ratio to actually be 4:3 regardless of cropping

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -49,8 +49,6 @@ static int g_screen_gun_height = SNES_HEIGHT;
 #define RETRO_GAME_TYPE_MULTI_CART      0x105 | 0x1000
 
 
-#define SNES_4_3 4.0f / 3.0f
-
 uint16 *screen_buffer = NULL;
 
 char g_rom_dir[1024];
@@ -788,7 +786,7 @@ float get_aspect_ratio(unsigned width, unsigned height)
 {
     if (aspect_ratio_mode == ASPECT_RATIO_4_3)
     {
-        return SNES_4_3;
+        return (4.0f * (MAX_SNES_HEIGHT - height)) / (3.0f * (MAX_SNES_WIDTH - width));
     }
     else if (aspect_ratio_mode == ASPECT_RATIO_1_1)
     {


### PR DESCRIPTION
*(I submitted this to the [libretro/snes9x](https://github.com/libretro/snes9x/pull/273) repo  (it's now merged there already) instead of here as I didn't know the libretro-specific code is also part this repo. Feel free to close this if you use other means of importing downstream commits.)*

Currently, the 4:3 aspect ratio core option does not work correctly. The AR is not preserved when using overscan cropping. The AR is stretched vertically with different crop values:

https://user-images.githubusercontent.com/1665903/152073956-8a2af8d6-bf13-4863-a406-ece72890311a.mp4

This PR aims to fix it by scaling the AR by the error introduced by cropping, so the image is always 4:3, regardless of cropping:

https://user-images.githubusercontent.com/1665903/152074098-e9e78678-b9bd-44b9-bd43-b6a23045b9d9.mp4