### PR TITLE
gtk: fix handling of relative paths for save states

### DIFF
--- a/gtk/src/gtk_file.cpp
+++ b/gtk/src/gtk_file.cpp
@@ -178,38 +178,8 @@ static int file_exists(const char *name)
     }
 }
 
-bool8 S9xOpenSnapshotFile(const char *fname, bool8 read_only, STREAM *file)
+bool8 S9xOpenSnapshotFile(const char *filename, bool8 read_only, STREAM *file)
 {
-    char filename[PATH_MAX + 1];
-    char drive[_MAX_DRIVE + 1];
-    char dir[_MAX_DIR + 1];
-    char ext[_MAX_EXT + 1];
-
-    _splitpath(fname, drive, dir, filename, ext);
-
-    if (*drive || *dir == '/' || (*dir == '.' && (*(dir + 1) == '/')))
-    {
-        snprintf(filename, PATH_MAX + 1, "%s", fname);
-
-        if (!file_exists(filename))
-        {
-            if (!*ext)
-                strcat(filename, ".s9x");
-        }
-    }
-    else
-    {
-        strcpy(filename, S9xGetDirectory(SNAPSHOT_DIR));
-        strcat(filename, SLASH_STR);
-        strcat(filename, fname);
-
-        if (!file_exists(filename))
-        {
-            if (!*ext)
-                strcat(filename, ".s9x");
-        }
-    }
-
 #ifdef ZLIB
     if (read_only)
     {

--- a/gtk/src/gtk_s9xwindow.cpp
+++ b/gtk/src/gtk_s9xwindow.cpp
@@ -838,7 +838,7 @@ void Snes9xWindow::save_state_dialog()
     dialog.add_button(Gtk::StockID("gtk-cancel"), Gtk::RESPONSE_CANCEL);
     dialog.add_button(Gtk::StockID("gtk-save"), Gtk::RESPONSE_ACCEPT);
     dialog.set_current_folder(S9xGetDirectory(SNAPSHOT_DIR));
-    dialog.set_current_name(S9xGetFilename(".sst", SNAPSHOT_DIR));
+    dialog.set_current_name(S9xBasename(S9xGetFilename(".sst", SNAPSHOT_DIR)));
     dialog.add_filter(get_save_states_file_filter());
     dialog.add_filter(get_all_files_filter());
 


### PR DESCRIPTION
This PR attempts to fix 2 issues regarding the handling of save states when snes9x-gtk is started with a relative path to a rom. (e.g `snes9x-gtk roms/romname.sfc`)

The first issue has to do with the quick save slots,  when using a relative filename for the rom, the Save State Slot menu doesn't work.
It turns out that for relative paths, `S9xOpenSnapshotFile` would mangle the filename by prepending the leading directory to the filename passed in parameter, leading to invalid paths.
For example, when snes9x-gtk is started with `build/rom.sfc` trying to use a quick save slot will yield this error:
```
zlib: Couldn't open snapshot file:
build/build/rom.000
```

I went for a simple approach here and removed the code that added mangled the path. Obviously losing the feature of adding the `.s9x` extension along the way.
All the callers of `S9xOpenSnapshotFile` seem to provide a proper filename... There's maybe the save dialog which could create a file without an extension if the user didn't provide one, but then one could argue that the user asked for it.

If the purpose of the code was indeed to add a default extension, that feature could be added back by checking if `ext` contains something, and appending the default extension if not. (I'm honestly not sure what the intent was with that `if`: https://github.com/snes9xgit/snes9x/blob/e705e71a97ce2955ef126b5aeea5ac6172959658/gtk/src/gtk_file.cpp#L190 Checking for absolute paths or `./`? but not `../` or `directory_name/file`?)

The second issue relates to the save dialog: there was a minor issue with its handling of relative paths.
`dialog.set_current_name` was called with the path of the suggested filename (with leading directories).
This broke in a way similar to above (leading directories prepended twice).
To reproduce, start `snes9x-gtk relative/path/to/rom.sfc` -> File -> Save State -> To File -> Save (using default filename) 
Using `S9xBasename` fixes this issue.