### PR TITLE
[Libretro] Create a separate aspect ratio option for "4:3 Preserved"

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -49,6 +49,8 @@ static int g_screen_gun_height = SNES_HEIGHT;
 #define RETRO_GAME_TYPE_MULTI_CART      0x105 | 0x1000
 
 
+#define SNES_4_3 4.0f / 3.0f
+
 uint16 *screen_buffer = NULL;
 
 char g_rom_dir[1024];
@@ -144,6 +146,7 @@ enum overscan_mode {
 };
 enum aspect_mode {
     ASPECT_RATIO_4_3,
+    ASPECT_RATIO_4_3_SCALED,
     ASPECT_RATIO_1_1,
     ASPECT_RATIO_NTSC,
     ASPECT_RATIO_PAL,
@@ -460,6 +463,8 @@ static void update_variables(void)
             newval = ASPECT_RATIO_PAL;
         else if (strcmp(var.value, "4:3") == 0)
             newval = ASPECT_RATIO_4_3;
+        else if (strcmp(var.value, "4:3 scaled") == 0)
+            newval = ASPECT_RATIO_4_3_SCALED;
         else if (strcmp(var.value, "uncorrected") == 0)
             newval = ASPECT_RATIO_1_1;
 
@@ -785,6 +790,10 @@ void retro_get_system_info(struct retro_system_info *info)
 float get_aspect_ratio(unsigned width, unsigned height)
 {
     if (aspect_ratio_mode == ASPECT_RATIO_4_3)
+    {
+        return SNES_4_3;
+    }
+    else if (aspect_ratio_mode == ASPECT_RATIO_4_3_SCALED)
     {
         return (4.0f * (MAX_SNES_HEIGHT - height)) / (3.0f * (MAX_SNES_WIDTH - width));
     }

--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -72,11 +72,12 @@ struct retro_core_option_definition option_defs_us[] = {
       "Choose the preferred content aspect ratio. This will only apply when RetroArch's aspect ratio is set to 'Core provided' in the Video settings.",
       {
          { "4:3",         NULL },
+         { "4:3 scaled",  "4:3 (Preserved)" },
          { "uncorrected", "Uncorrected" },
          { "auto",        "Auto" },
          { "ntsc",        "NTSC" },
          { "pal",         "PAL" },
-         { NULL, NULL},
+         { NULL, NULL },
       },
       "4:3"
    },

--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -77,7 +77,7 @@ struct retro_core_option_definition option_defs_us[] = {
          { "auto",        "Auto" },
          { "ntsc",        "NTSC" },
          { "pal",         "PAL" },
-         { NULL, NULL },
+         { NULL, NULL},
       },
       "4:3"
    },

--- a/libretro/libretro_core_options_intl.h
+++ b/libretro/libretro_core_options_intl.h
@@ -96,6 +96,7 @@ struct retro_core_option_definition option_defs_tr[] = {
       "Tercih edilen içerik en boy oranını seçin. Bu, yalnızca RetroArch’ın en boy oranı Video ayarlarında 'Core tarafından' olarak ayarlandığında uygulanacaktır.",
       {
          { "4:3",         NULL },
+         { "4:3 scaled",  "4:3 (Korunmuş)" },
          { "uncorrected", "Düzeltilmemiş" },
          { "auto",        "Otomatik" },
          { "ntsc",        "NTSC" },


### PR DESCRIPTION
Upstreaming https://github.com/libretro/snes9x/pull/275

Partially based on the discussion had in https://github.com/snes9xgit/snes9x/pull/734, but also because of my preference for the old behavior, this PR separates it into it's own option.