### PR TITLE
Fix Rockman X 1.0 memory mapping to stop triggering the botched copy …

### DIFF
--- a/memmap.cpp
+++ b/memmap.cpp
@@ -2508,9 +2508,6 @@ void CMemory::InitROM (void)
 			}
 		}
 		else
-		if (strncmp(ROMName, "ROCKMAN X", 9) == 0 && ROMVersion == 0)
-			Map_RockmanXRev0LoROMMap();
-		else
 			Map_LoROMMap();
     }
 
@@ -3227,21 +3224,6 @@ void CMemory::Map_BSSA1LoROMMap(void)
 	BWRAM = SRAM;
 }
 
-void CMemory::Map_RockmanXRev0LoROMMap(void)
-{
-	printf("Map_RockmanXRev0LoROMMap\n");
-	map_System();
-	
-	map_lorom(0x00, 0x2f, 0x8000, 0xffff, CalculatedSize);
-	map_lorom(0x40, 0x6f, 0x0000, 0xffff, CalculatedSize);
-	map_lorom(0x80, 0xaf, 0x8000, 0xffff, CalculatedSize);
-	map_lorom(0xc0, 0xef, 0x0000, 0xffff, CalculatedSize);
-	
-	map_WRAM();
-
-	map_WriteProtectROM();
-}
-
 void CMemory::Map_HiROMMap (void)
 {
 	printf("Map_HiROMMap\n");
@@ -3701,6 +3683,11 @@ void CMemory::ApplyROMFixes (void)
 		Timings.RenderPos = 32;
 	else if (match_na("ADVENTURES OF FRANKEN") && Settings.PAL)
 		Timings.RenderPos = 32;
+
+	// Copy protection fix
+	if (match_na("ROCKMAN X") && ROMVersion == 0) {
+		map_index(0x70, 0x7d, 0x0000, 0xffff, MAP_LOROM_SRAM, MAP_TYPE_RAM);
+	}
 }
 
 // BPS % UPS % IPS

--- a/memmap.cpp
+++ b/memmap.cpp
@@ -2208,10 +2208,11 @@ void CMemory::ParseSNESHeader (uint8 *RomHeader)
 	else
 		ROMSize = RomHeader[0x27];
 
-	SRAMSize  = bs ? 5 /* BS-X */    : RomHeader[0x28];
-	ROMSpeed  = bs ? RomHeader[0x28] : RomHeader[0x25];
-	ROMType   = bs ? 0xE5 /* BS-X */ : RomHeader[0x26];
-	ROMRegion = bs ? 0               : RomHeader[0x29];
+	SRAMSize   = bs ? 5 /* BS-X */    : RomHeader[0x28];
+	ROMSpeed   = bs ? RomHeader[0x28] : RomHeader[0x25];
+	ROMType    = bs ? 0xE5 /* BS-X */ : RomHeader[0x26];
+	ROMRegion  = bs ? 0               : RomHeader[0x29];
+	ROMVersion = RomHeader[0x2B];
 
 	ROMChecksum           = RomHeader[0x2E] + (RomHeader[0x2F] << 8);
 	ROMComplementChecksum = RomHeader[0x2C] + (RomHeader[0x2D] << 8);
@@ -2506,6 +2507,9 @@ void CMemory::InitROM (void)
 				Map_SufamiTurboPseudoLoROMMap();
 			}
 		}
+		else
+		if (strncmp(ROMName, "ROCKMAN X", 9) == 0 && ROMVersion == 0)
+			Map_RockmanXRev0LoROMMap();
 		else
 			Map_LoROMMap();
     }
@@ -3224,6 +3228,21 @@ void CMemory::Map_BSSA1LoROMMap(void)
 		SA1.Map[c] = SA1.WriteMap[c] = (uint8 *) MAP_BWRAM_BITMAP;
 
 	BWRAM = SRAM;
+}
+
+void CMemory::Map_RockmanXRev0LoROMMap(void)
+{
+	printf("Map_RockmanXRev0LoROMMap\n");
+	map_System();
+	
+	map_lorom(0x00, 0x2f, 0x8000, 0xffff, CalculatedSize);
+	map_lorom(0x40, 0x6f, 0x0000, 0xffff, CalculatedSize);
+	map_lorom(0x80, 0xaf, 0x8000, 0xffff, CalculatedSize);
+	map_lorom(0xc0, 0xef, 0x0000, 0xffff, CalculatedSize);
+	
+	map_WRAM();
+
+	map_WriteProtectROM();
 }
 
 void CMemory::Map_HiROMMap (void)

--- a/memmap.h
+++ b/memmap.h
@@ -156,7 +156,6 @@ struct CMemory
 	void	Map_SDD1LoROMMap (void);
 	void	Map_SA1LoROMMap (void);
 	void	Map_BSSA1LoROMMap (void);
-	void	Map_RockmanXRev0LoROMMap(void);
 	void	Map_HiROMMap (void);
 	void	Map_ExtendedHiROMMap (void);
 	void	Map_SPC7110HiROMMap (void);

--- a/memmap.h
+++ b/memmap.h
@@ -79,6 +79,7 @@ struct CMemory
 	uint8	ROMSpeed;
 	uint8	ROMType;
 	uint8	ROMSize;
+	uint8	ROMVersion;
 	uint32	ROMChecksum;
 	uint32	ROMComplementChecksum;
 	uint32	ROMCRC32;
@@ -155,6 +156,7 @@ struct CMemory
 	void	Map_SDD1LoROMMap (void);
 	void	Map_SA1LoROMMap (void);
 	void	Map_BSSA1LoROMMap (void);
+	void	Map_RockmanXRev0LoROMMap(void);
 	void	Map_HiROMMap (void);
 	void	Map_ExtendedHiROMMap (void);
 	void	Map_SPC7110HiROMMap (void);


### PR DESCRIPTION
…protection

Cartridges of the 1.0 version of Rockman X have bodge wiring to disable some ROM mirroring due to faulty copy protection being triggered when it shouldn't, which is described [here](https://web.archive.org/web/20210127154007/https://byuu.net/cartridges/boards/) better than I could ever explain it.

Before snes9x 1.57, this wasn't an issue because CMemory::map_LoROMSRAM still ran when opening LoROMs with SRAM size 0. However, [this commit](https://github.com/snes9xgit/snes9x/commit/386bfe0aa9c33b33d84e941f0d2055830dde3d00) stopped mapping SRAM in that case, which re-enabled those copy protection issues.

The reason for adding CMemory::Map_RockmanXRev0LoROMMap was that this is a special hardware case that modifies the behaviour of the stock board, and other special carts such as the Sufami Turbo have their own functions as well. If anyone has any recommendations on how to implement this functionality that may be preferable, please let me know.

Thanks!