### PR TITLE
Revert "Change where we break S9xMainLoop/Scan for input ("Brunnis lag fix")" - Causes incorrect behaviour in Super Punch-Out!!

### DIFF
--- a/cpuexec.cpp
+++ b/cpuexec.cpp
@@ -298,6 +298,7 @@ void S9xDoHEventProcessing (void)
 
 				ICPU.Frame++;
 				PPU.HVBeamCounterLatched = 0;
+				CPU.Flags |= SCAN_KEYS_FLAG;
 			}
 
 			// From byuu:
@@ -327,9 +328,6 @@ void S9xDoHEventProcessing (void)
 			if (CPU.V_Counter == PPU.ScreenHeight + FIRST_VISIBLE_LINE)	// VBlank starts from V=225(240).
 			{
 				S9xEndScreenRefresh();
-
-				CPU.Flags |= SCAN_KEYS_FLAG;
-
 				PPU.HDMA = 0;
 				// Bits 7 and 6 of $4212 are computed when read in S9xGetPPU.
 			#ifdef DEBUGGER


### PR DESCRIPTION
This reverts commit 10e0ef005d1d86301d8b87215ef23821bdd4d441.

Hello again,

This commit causes incorrect behaviour in Super Punch-Out!! due to punches starting earlier than they are supposed to after input. See here for a demonstration: [https://www.youtube.com/watch?v=nHr5W12TYrg](https://www.youtube.com/watch?v=nHr5W12TYrg)

The fastest possible time on Piston Hurricane is 5"49, which requires a manually timed gut punch at 2"05 on the in-game timer. Pressing Y one frame earlier will cause him to block your punch. On the left I demonstrate obtaining a 5"49 by frame advancing so you can see the timed punch. On the right, I try the same thing again on 1.56, but pressing Y at 2"05 causes him to block the punch because it starts earlier than it should. Delaying this punch by 1 frame allows you to complete the strategy on 1.56, but with a final time of 5"50, one frame slower than what should be possible. Reverting the polling change from 10e0ef005d1d86301d8b87215ef23821bdd4d441 fixes the issue. The current TAS of the game done on BizHawk 1.5.1 gets a 5"49, and here is a video of me obtaining a 5"49 on real hardware: [https://www.youtube.com/watch?v=V_EMDAx9WcA](https://www.youtube.com/watch?v=V_EMDAx9WcA)

I believe there are other examples of strategies not working due to this, but this is the most commonly encountered due to it being one of the easier fights to execute. If there are other games that are similarly sensitive to frame timings, they may be affected by this as well.

Thanks.
