### PR TITLE
libretro: Fix audio not being submitted when rendering is disabled

### DIFF
--- a/gfx.cpp
+++ b/gfx.cpp
@@ -98,6 +98,9 @@ bool8 S9xGraphicsInit (void)
 		}
 	}
 
+	GFX.EndScreenRefreshCallback = NULL;
+	GFX.EndScreenRefreshCallbackData = NULL;
+
 	return (TRUE);
 }
 
@@ -107,6 +110,9 @@ void S9xGraphicsDeinit (void)
 	if (GFX.SubScreen)  { free(GFX.SubScreen);  GFX.SubScreen  = NULL; }
 	if (GFX.ZBuffer)    { free(GFX.ZBuffer);    GFX.ZBuffer    = NULL; }
 	if (GFX.SubZBuffer) { free(GFX.SubZBuffer); GFX.SubZBuffer = NULL; }
+
+	GFX.EndScreenRefreshCallback = NULL;
+	GFX.EndScreenRefreshCallbackData = NULL;
 }
 
 void S9xGraphicsScreenResize (void)
@@ -263,6 +269,15 @@ void S9xEndScreenRefresh (void)
 			}
 		}
 	}
+
+	if (GFX.EndScreenRefreshCallback)
+		GFX.EndScreenRefreshCallback(GFX.EndScreenRefreshCallbackData);
+}
+
+void S9xSetEndScreenRefreshCallback(const SGFX::Callback cb, void *const data)
+{
+	GFX.EndScreenRefreshCallback = cb;
+	GFX.EndScreenRefreshCallbackData = data;
 }
 
 void RenderLine (uint8 C)

--- a/gfx.h
+++ b/gfx.h
@@ -11,6 +11,8 @@
 
 struct SGFX
 {
+	typedef void (*Callback)(void *);
+
 	const uint32 Pitch = sizeof(uint16) * MAX_SNES_WIDTH;
 	const uint32 RealPPL = MAX_SNES_WIDTH; // true PPL of Screen buffer
 	const uint32 ScreenSize =  MAX_SNES_WIDTH * SNES_HEIGHT_EXTENDED;
@@ -67,6 +69,9 @@ struct SGFX
 	const char	*InfoString;
 	uint32	InfoStringTimeout;
 	char	FrameDisplayString[256];
+
+	Callback EndScreenRefreshCallback;
+	void *EndScreenRefreshCallbackData;
 };
 
 struct SBG
@@ -202,6 +207,7 @@ struct COLOR_SUB
 
 void S9xStartScreenRefresh (void);
 void S9xEndScreenRefresh (void);
+void S9xSetEndScreenRefreshCallback(SGFX::Callback cb, void *data);
 void S9xBuildDirectColourMaps (void);
 void RenderLine (uint8);
 void S9xComputeClipWindows (void);


### PR DESCRIPTION
In commit 6628042fe386197648334063f70e6a94350b9bf7, audio upload was
moved from retro_run() to S9xDeinitUpdate(). This breaks audio when
runahead is enabled in RetroArch.

With second-instance runahead, S9xDeinitUpdate() is not called when
video rendering is disabled and thus the core instance responsible for
audio is not uploading the audio. With single-instance runahead, audio
is uploaded twice because video rendering is always enabled and thus
S9xDeinitUpdate() gets called twice per frame.

Fix this by introducing a callback that gets called at the end of every
screen refresh, regardless of whether or not rendering is active for
this frame. We can then decide in the callback whether or not audio
should be uploaded.