### PR TITLE
Fixes issue where non-archive msu-1 files would have improper file extensions

### DIFF
--- a/gtk/src/gtk_file.cpp
+++ b/gtk/src/gtk_file.cpp
@@ -121,8 +121,15 @@ const char *S9xGetFilename(const char *ex, enum s9x_getdirtype dirtype)
     static std::string filename;
     fs::path path(S9xGetDirectory(dirtype));
     path /= fs::path(Memory.ROMFilename).filename();
-    path.replace_extension(ex);
-    filename = path.string();
+    //Fixes issue with MSU-1 on linux
+    if(ex[0] == '-') {
+        path.replace_extension("");
+        filename = path.string();
+        filename.append(ex);
+    } else {
+        path.replace_extension(ex);
+        filename = path.string();
+    }
     return filename.c_str();
 }
 


### PR DESCRIPTION
I recently noticed an issue where SNES9x was not properly loading MSU-1 files on GTK Linux.  After stepping through the code, I found out that it was due to the fact that it was attempting to open <romname>.-1.pcm rather than the correct <romname>-1.pcm.

This should correct the behavior with regards to the PCM files while keeping the functionality as it was for the non PCM files.