### PR TITLE
macOS: Set LSApplicationCategoryType to games

### DIFF
--- a/macosx/Snes9x/Info.plist
+++ b/macosx/Snes9x/Info.plist
@@ -177,6 +177,8 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.games</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>NSMainNibFile</key>


### PR DESCRIPTION
https://developer.apple.com/documentation/bundleresources/information_property_list/lsapplicationcategorytype macOS will auto-add it to the agmes folder in macOS Launchpad