### PR TITLE
Gtk: Fix some keys not being usable with modifiers

### DIFF
--- a/gtk/src/gtk_binding.cpp
+++ b/gtk/src/gtk_binding.cpp
@@ -17,7 +17,22 @@ Binding::Binding()
 
 Binding::Binding(GdkEventKey *event)
 {
-    event->keyval = gdk_keyval_to_lower(event->keyval);
+    GdkKeymapKey* keys;
+    guint* keyvals;
+    int n_entries;
+
+    gdk_keymap_get_entries_for_keycode(
+        gdk_keymap_get_for_display(top_level->window->get_display()->gobj()),
+        event->hardware_keycode,
+        &keys,
+        &keyvals,
+        &n_entries
+    );
+    event->keyval = keyvals[0];
+
+    g_free(keys);
+    g_free(keyvals);
+
     value = BINDING_KEY | (event->keyval & BINDING_KEY_MASK);
 
     /* Strip modifiers from modifiers */


### PR DESCRIPTION
With the GTK frontend, some keys - for example `:/;` - are only usable with Shift either pressed or not pressed. This is because the code uses `gdk_keyval_to_lower` to handle this, which has a slightly different purpose and won't convert `:` to `;`.

Here my fix is to translate the event's `hardware_keycode` back into a `keyval`, which should give the value for the key with no modifiers pressed. This seems to work for my setup, but there might be a better way of doing it that I couldn't find.