### PR TITLE
Fix Libretro netplay immediately disconnecting

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -1126,7 +1126,7 @@ bool retro_load_game(const struct retro_game_info *game)
         }
 
         else
-            rom_loaded = Memory.LoadROMMem((const uint8_t*)game->data ,game->size, game->path);
+            rom_loaded = Memory.LoadROMMem((const uint8_t*)game->data ,game->size, g_basename);
 
         if(biosrom) delete[] biosrom;
     }


### PR DESCRIPTION
Followup to https://github.com/snes9xgit/snes9x/commit/33d84d31b8b86e10a3d0638d1282ce2f0063d414, which fixed MSU-1 loading for the Libretro core, but caused Libretro netplay to immediately disconnect between separate devices due to passing the full rom path (`game->path`) as the `optional_rom_filename` variable for `LoadROMMem`.
This changes it to use `g_basename` instead.