### PR TITLE
Support Nimbus+ controller in mac-joypad.mm findControls()

### DIFF
--- a/macosx/mac-joypad.mm
+++ b/macosx/mac-joypad.mm
@@ -282,7 +282,9 @@ void findControls(struct JoypadDevice &device, NSDictionary *properties, NSMutab
 
     int usagePage = [properties[@kIOHIDElementUsagePageKey] intValue];
     int usage = [properties[@kIOHIDElementUsageKey] intValue];
-    if (usagePage == kHIDPage_Button)
+    if (usagePage == kHIDPage_Button ||
+        (usagePage == kHIDPage_GenericDesktop && (usage == kHIDUsage_GD_DPadUp || usage == kHIDUsage_GD_DPadDown || usage == kHIDUsage_GD_DPadLeft || usage == kHIDUsage_GD_DPadRight))
+        || (usagePage == kHIDPage_Consumer && (usage == kHIDUsage_Csmr_ACProperties || usage == kHIDUsage_Csmr_ACExit)))
     {
         [buttons addObject:properties];
     }

--- a/macosx/mac-joypad.mm
+++ b/macosx/mac-joypad.mm
@@ -283,8 +283,9 @@ void findControls(struct JoypadDevice &device, NSDictionary *properties, NSMutab
     int usagePage = [properties[@kIOHIDElementUsagePageKey] intValue];
     int usage = [properties[@kIOHIDElementUsageKey] intValue];
     if (usagePage == kHIDPage_Button ||
-        (usagePage == kHIDPage_GenericDesktop && (usage == kHIDUsage_GD_DPadUp || usage == kHIDUsage_GD_DPadDown || usage == kHIDUsage_GD_DPadLeft || usage == kHIDUsage_GD_DPadRight))
-        || (usagePage == kHIDPage_Consumer && (usage == kHIDUsage_Csmr_ACProperties || usage == kHIDUsage_Csmr_ACExit)))
+        usagePage == kHIDPage_Consumer ||
+        (usagePage == kHIDPage_GenericDesktop && (usage == kHIDUsage_GD_DPadUp || usage == kHIDUsage_GD_DPadDown || usage == kHIDUsage_GD_DPadLeft || usage == kHIDUsage_GD_DPadRight ||
+                                                  usage == kHIDUsage_GD_Start || usage == kHIDUsage_GD_Select || usage == kHIDUsage_GD_SystemMainMenu)))
     {
         [buttons addObject:properties];
     }


### PR DESCRIPTION
The findControls() routine was not finding several of the buttons on my Nimbus+ controller so that I could not configure those buttons in

    Settings > Controls > Nimbus+

A, B, X, Y, and the L and R shoulder buttons are detected by the existing code. The D-pad and the 'start' and 'select' standins are not.

One odd thing that happened the first time I played with this change was that after configuring the new buttons and loading up a game the buttons seemed to be initially in a random state and so the game seemed to behave like some random buttons were held down. After pressing and releasing all the new buttons the game seemed to behave more normally. I'm not sure of my diagnosis because it only happened the one time and I didn't have an opportunity to reproduce or debug whatever happened.