### PR TITLE
Fix GCC 13 build issue

### DIFF
--- a/external/VulkanMemoryAllocator-Hpp/include/vk_mem_alloc.h
+++ b/external/VulkanMemoryAllocator-Hpp/include/vk_mem_alloc.h
@@ -23,7 +23,10 @@
 #ifndef AMD_VULKAN_MEMORY_ALLOCATOR_H
 #define AMD_VULKAN_MEMORY_ALLOCATOR_H
 
-#include <cstdio>
+#if VMA_STATS_STRING_ENABLED
+  // Needed for snprintf()
+  #include <cstdio>
+#endif
 
 /** \mainpage Vulkan Memory Allocator
 

--- a/external/VulkanMemoryAllocator-Hpp/include/vk_mem_alloc.h
+++ b/external/VulkanMemoryAllocator-Hpp/include/vk_mem_alloc.h
@@ -23,6 +23,8 @@
 #ifndef AMD_VULKAN_MEMORY_ALLOCATOR_H
 #define AMD_VULKAN_MEMORY_ALLOCATOR_H
 
+#include <cstdio>
+
 /** \mainpage Vulkan Memory Allocator
 
 <b>Version 3.1.0-development</b>


### PR DESCRIPTION
Prevent g++ from complaining that snprintf() is undefined when VMA_STATS_STRING_ENABLED is set.