### PR TITLE
More i18n

### DIFF
--- a/common/audio/s9x_sound_driver_pulse.cpp
+++ b/common/audio/s9x_sound_driver_pulse.cpp
@@ -11,6 +11,9 @@
 #include <fcntl.h>
 #include <sys/ioctl.h>
 #include <sys/time.h>
+#include "fmt/format.h"
+#include "messages.h"
+#include "snes9x.h"
 
 S9xPulseSoundDriver::S9xPulseSoundDriver()
 {
@@ -116,11 +119,12 @@ bool S9xPulseSoundDriver::open_device(int playback_rate, int buffer_size_ms)
     buffer_attr.minreq = pa_usec_to_bytes(3000, &ss);
     buffer_attr.prebuf = buffer_attr.tlength / 2;
 
-    printf("PulseAudio sound driver initializing...\n");
+    S9xMessage(S9X_INFO, S9X_NO_INFO, "Initializing PulseAudio sound driver…");
 
-    printf("    --> (%dhz, 16-bit Stereo, %dms)...",
-           playback_rate,
-           buffer_size_ms);
+    S9xMessage(S9X_INFO, S9X_NO_INFO,
+        fmt::format("    --> ({0:Ld} Hz, 16‑bit stereo, {1:Ld} ms)…",
+            playback_rate,
+            buffer_size_ms).c_str());
 
     int err = PA_ERR_UNKNOWN;
     mainloop = pa_threaded_mainloop_new();
@@ -159,7 +163,7 @@ bool S9xPulseSoundDriver::open_device(int playback_rate, int buffer_size_ms)
 
     buffer_size = actual_buffer_attr->tlength;
 
-    printf("OK\n");
+    S9xMessage(S9X_INFO, S9X_NO_INFO, "OK");
 
     return true;
 }

--- a/gtk/po/POTFILES.in
+++ b/gtk/po/POTFILES.in
@@ -3,6 +3,7 @@ src/gtk_cheat.cpp
 src/gtk_config.cpp
 src/gtk_display_driver_opengl.cpp
 src/gtk_netplay.cpp
+src/gtk_netplay_dialog.cpp
 src/gtk_preferences.cpp
 src/gtk_s9x.cpp
 src/gtk_s9xwindow.cpp

--- a/gtk/po/pl.po
+++ b/gtk/po/pl.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Snes9x 1.62.3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-29 19:58+0200\n"
-"PO-Revision-Date: 2023-08-24 11:31+0200\n"
+"POT-Creation-Date: 2023-10-29 23:56+0100\n"
+"PO-Revision-Date: 2023-10-30 12:00+0100\n"
 "Last-Translator: Jake Smarter <JakeSmarter@users.noreply.github.com>\n"
 "Language-Team:\n"
 "Language: pl\n"
@@ -98,98 +98,131 @@ msgstr "Nie można utworzyć katalogu konfiguracyjnego „{}”\n"
 msgid "Connection Error"
 msgstr "Błąd połączenia"
 
-#: src/gtk_preferences.cpp:21
+#: src/gtk_netplay_dialog.cpp:31
+msgid "frame behind"
+msgid_plural "frames behind"
+msgstr[0] "klatkę"
+msgstr[1] "klatki"
+msgstr[2] "klatek"
+
+#: src/gtk_preferences.cpp:19
 msgid "Same location as current game"
 msgstr "Położenie bieżącej gry"
 
-# TODO: make not translatable because proper name
-#: src/gtk_preferences.cpp:130
-msgid "HQ2x"
-msgstr "HQ2x"
+#: src/gtk_preferences.cpp:110
+msgid "{0:Ld}×{1:Ld} @ {2:.3Lf} Hz"
+msgstr "{0:Ld}×{1:Ld} z częstotliwością {2:.3Lf} Hz"
 
-# TODO: make not translatable because proper name
-#: src/gtk_preferences.cpp:131
-msgid "HQ3x"
-msgstr "HQ3x"
-
-# TODO: make not translatable because proper name
-#: src/gtk_preferences.cpp:132
-msgid "HQ4x"
-msgstr "HQ4x"
-
-# TODO: make not translatable because proper name
-#: src/gtk_preferences.cpp:136
-msgid "2xBRZ"
-msgstr "2xBRZ"
-
-# TODO: make not translatable because proper name
-#: src/gtk_preferences.cpp:137
-msgid "3xBRZ"
-msgstr "3xBRZ"
-
-# TODO: make not translatable because proper name
-#: src/gtk_preferences.cpp:138
-msgid "4xBRZ"
-msgstr "4xBRZ"
-
-#: src/gtk_preferences.cpp:145
-msgid "OpenGL - Use 3D graphics hardware"
+#: src/gtk_preferences.cpp:143
+msgid "OpenGL – Use 3D graphics hardware"
 msgstr "OpenGL — używaj sprzętu graficznego 3D"
 
-#: src/gtk_preferences.cpp:147
-msgid "XVideo - Use hardware video blitter"
+#: src/gtk_preferences.cpp:145
+msgid "XVideo – Use hardware video blitter"
 msgstr "XVideo — używaj sprzętowego blittera wideo"
 
-#: src/gtk_preferences.cpp:149
+#: src/gtk_preferences.cpp:147
 msgid "Vulkan"
 msgstr "Vulkan"
 
-#: src/gtk_preferences.cpp:151
-msgid "None - Use software scaler"
+#: src/gtk_preferences.cpp:149
+msgid "None – Use software scaler"
 msgstr "Brak — używaj skalowania oprogramowania"
 
-#: src/gtk_preferences.cpp:238
+#: src/gtk_preferences.cpp:179 src/gtk_preferences.cpp:446
+msgid "thread for filtering and scaling"
+msgid_plural "threads for filtering and scaling"
+msgstr[0] "wątek do filtrowania i skalowania"
+msgstr[1] "wątki do filtrowania i skalowania"
+msgstr[2] "wątków do filtrowania i skalowania"
+
+#: src/gtk_preferences.cpp:236 src/gtk_preferences.cpp:500
+msgid "millisecond"
+msgid_plural "milliseconds"
+msgstr[0] "milisekunda"
+msgstr[1] "milisekundy"
+msgstr[2] "milisekund"
+
+#: src/gtk_preferences.cpp:260 src/gtk_preferences.cpp:476
+msgid "second after change"
+msgid_plural "seconds after change"
+msgstr[0] "sekundę po zmianie"
+msgstr[1] "sekundy po zmianie"
+msgstr[2] "sekund po zmianie"
+
+#: src/gtk_preferences.cpp:271
 msgid "Snes9x version: "
 msgstr "Wersja Snes9x: "
 
-#: src/gtk_preferences.cpp:239
+#: src/gtk_preferences.cpp:272
 msgid "GTK+ port version: "
 msgstr "Przełożenie wersji GTK+: "
 
-#: src/gtk_preferences.cpp:241
+#: src/gtk_preferences.cpp:274
 msgid "English localization by Brandon Wright"
 msgstr "Angielskojęzycznej lokalizacji dokonał Brandon Wright"
 
-#: src/gtk_preferences.cpp:265
+#: src/gtk_preferences.cpp:298
 msgid "Select directory"
 msgstr "Markowanie katalogu"
 
-#: src/gtk_preferences.cpp:338
+#: src/gtk_preferences.cpp:323
+msgid "{0:.4Lf} Hz"
+msgstr "{0:.4Lf} Hz"
+
+#: src/gtk_preferences.cpp:328
+msgid "{0:Ld} Hz"
+msgstr "{0:Ld} Hz"
+
+#: src/gtk_preferences.cpp:379
 msgid "Select Shader File"
 msgstr "Markowanie pliku cieniowania"
 
-#: src/gtk_preferences.cpp:669
+#: src/gtk_preferences.cpp:720
 msgid ""
 "Changing the SRAM directory with a game loaded will replace the .srm file in "
 "the selected directory with the SRAM from the running game. If this is not "
 "what you want, click 'cancel'."
 msgstr ""
-"Zmienia katalogu SRAM podczas załadowanej gry zastąpi plik .srm w zamarkowanym"
-" katalogu SRAMem uruchomionej gry. Jeśli tego nie chcesz, to kliknij „Anuluj”."
+"Zmienia katalogu SRAM podczas załadowanej gry zastąpi plik .srm w "
+"zamarkowanym katalogu SRAMem uruchomionej gry. Jeśli tego nie chcesz, to "
+"kliknij „Anuluj”."
 
-#: src/gtk_preferences.cpp:674
+#: src/gtk_preferences.cpp:725
 msgid "Warning: Possible File Overwrite"
 msgstr "Ostrzeżenie nadpisania pliku"
 
-#: src/gtk_preferences.cpp:929
+#: src/gtk_preferences.cpp:980
 msgid "Current joystick centers have been saved."
 msgstr "Zapisano bieżące wycentrowania joysticków."
 
-#: src/gtk_preferences.cpp:930
+#: src/gtk_preferences.cpp:981
 msgid "Calibration Complete"
 msgstr "Ukończono kalibrację"
 
-#: src/gtk_s9xwindow.cpp:48 src/snes9x.ui:8430
+#: src/gtk_s9x.cpp:206
+msgid "Using rewind buffer of {0}\n"
+msgstr ""
+
+#: src/gtk_s9x.cpp:598
+msgid ""
+"GTK port options:\n"
+"-filter [option]               Use a filter to scale the image.\n"
+"                               [option] is one of: none supereagle 2xsai\n"
+"                               super2xsai hq2x hq3x hq4x 2xbrz 3xbrz 4xbrz "
+"epx ntsc\n"
+"\n"
+"-mutesound                     Disables sound output.\n"
+msgstr ""
+"Opcje GTK:\n"
+"-filter [opcja]                stosuje filtr skalowania obrazu\n"
+"                               [opcja], to jeden z: none, supereagle, 2xsai,\n"
+"                               super2xsai, hq2x, hq3x, hq4x, 2xbrz, 3xbrz,\n"
+"                               4xbrz, epx, ntsc\n"
+"\n"
+"-mutesound                     wyłącza dźwięk\n"
+
+#: src/gtk_s9xwindow.cpp:48 src/snes9x.ui:8405
 msgid "Save States"
 msgstr "Zapisy stanów"
 
@@ -230,8 +263,8 @@ msgid "Load Saved State"
 msgstr "Ładowanie zapisanego stanu"
 
 #: src/gtk_s9xwindow.cpp:796
-msgid "The current frame in the movie is <b>%d</b>."
-msgstr "Bieżącą klatką wideo jest <b>%'d</b>."
+msgid "The current frame in the movie is <b>{0:Ld}</b>."
+msgstr "Bieżącą klatką wideo jest <b>{0:Ld}</b>."
 
 #: src/gtk_s9xwindow.cpp:829
 msgid "Save State"
@@ -246,7 +279,6 @@ msgid "Couldn't save SPC file:"
 msgstr "Nie można zapisać pliku SPC:"
 
 #: src/gtk_s9xwindow.cpp:888
-#, c-format
 msgid ""
 "<b>Information for %s</b>\n"
 "\n"
@@ -320,613 +352,541 @@ msgstr "Profil cieniowania"
 msgid "Shader Parameters"
 msgstr "Parametry cieniowania"
 
-#: src/snes9x.ui:9
+#: src/snes9x.ui:10
 msgid "About Snes9x"
 msgstr "O Snes9x"
 
-# TODO: remove
-#: src/snes9x.ui:48
-msgid "label106"
-msgstr ""
-
-#: src/snes9x.ui:278
+#: src/snes9x.ui:283
 msgid "Snes9x Cheats"
 msgstr "Cheaty Snes9x"
 
-#: src/snes9x.ui:396
+#: src/snes9x.ui:401
 msgid "Update Cheat"
 msgstr "Z_aktualizuj cheat"
 
-#: src/snes9x.ui:411
+#: src/snes9x.ui:416
 msgid "Disable All"
 msgstr "_Wyłącz wszystkie"
 
-#: src/snes9x.ui:427
+#: src/snes9x.ui:432
 msgid "Delete All Cheats"
 msgstr "U_suń wszystkie cheaty"
 
-#: src/snes9x.ui:442
+#: src/snes9x.ui:447
 msgid "Search Cheat Database"
 msgstr "Wyszukaj cheat z _bazy danych"
 
-#: src/snes9x.ui:484
+#: src/snes9x.ui:489
 msgid "Code:"
 msgstr "_Kod:"
 
-#: src/snes9x.ui:521
+#: src/snes9x.ui:526
 msgid "Description:"
 msgstr "_Opis:"
 
-#: src/snes9x.ui:568
+#: src/snes9x.ui:573
 msgid "Advance to Frame"
 msgstr "Przejście do klatki"
 
-#: src/snes9x.ui:637
+#: src/snes9x.ui:642
 msgid "The current frame in the movie is"
 msgstr "Bieżąca klatka w wideo jest"
 
-#: src/snes9x.ui:658
-msgid "Fast-forward to frame"
+#: src/snes9x.ui:663
+msgid "Fast‑forward to frame"
 msgstr "Przewiń do klatki"
 
-#: src/snes9x.ui:819
+#: src/snes9x.ui:806
 msgid "Black"
 msgstr "Czerń"
 
-#: src/snes9x.ui:822
+#: src/snes9x.ui:809
 msgid "Color bars"
 msgstr "Kolorowe belki"
 
-#: src/snes9x.ui:825
+#: src/snes9x.ui:812
 msgid "Pixel art patterns"
 msgstr "Pikselowe wzory"
 
-#: src/snes9x.ui:828
+#: src/snes9x.ui:815
 msgid "Dithered gradient"
 msgstr "Punktowany gradient"
 
-#: src/snes9x.ui:831
+#: src/snes9x.ui:818
 msgid "Color bars and patterns"
 msgstr "Kolorowe belki i wzory"
 
-#: src/snes9x.ui:834
+#: src/snes9x.ui:821
 msgid "Starfield"
 msgstr "Gwiazdy"
 
-#: src/snes9x.ui:837
+#: src/snes9x.ui:824
 msgid "Snow"
 msgstr "Śnieg"
 
-# TODO: make not translatable because proper name
-#: src/snes9x.ui:848
-msgid "Game Genie"
-msgstr "Game Genie"
-
-# TODO: make not translatable because proper name
-#: src/snes9x.ui:851
-msgid "Pro Action Replay"
-msgstr "Pro Action Replay"
-
-# TODO: make not translatable because proper name
-#: src/snes9x.ui:854
-msgid "Goldfinger"
-msgstr "Goldfinger"
-
-#: src/snes9x.ui:865 src/snes9x.ui:888
+#: src/snes9x.ui:852 src/snes9x.ui:875
 msgid "12.5%"
 msgstr "12,5%"
 
-#: src/snes9x.ui:868 src/snes9x.ui:891
+#: src/snes9x.ui:855 src/snes9x.ui:878
 msgid "25%"
 msgstr "25%"
 
-#: src/snes9x.ui:871 src/snes9x.ui:894
+#: src/snes9x.ui:858 src/snes9x.ui:881
 msgid "50%"
 msgstr "50%"
 
-#: src/snes9x.ui:874 src/snes9x.ui:897
+#: src/snes9x.ui:861 src/snes9x.ui:884
 msgid "100%"
 msgstr "100%"
 
-#: src/snes9x.ui:885
+#: src/snes9x.ui:872
 msgid "0%"
 msgstr "0%"
 
-#: src/snes9x.ui:908 src/snes9x.ui:1989
+#: src/snes9x.ui:895
+msgctxt "filter list"
 msgid "None"
 msgstr "Brak"
 
-# TODO: make not translatable because proper name
-#: src/snes9x.ui:911
-msgid "SuperEagle"
-msgstr "SuperEagle"
-
-# TODO: make not translatable because proper name
-#: src/snes9x.ui:914
-msgid "2xSaI"
-msgstr "2xSaI"
-
-# TODO: make not translatable because proper name
-#: src/snes9x.ui:917
-msgid "Super2xSaI"
-msgstr "Super2xSaI"
-
-# TODO: make not translatable because proper name
-#: src/snes9x.ui:920
-msgid "EPX"
-msgstr "EPX"
-
-# TODO: make not translatable because proper name
-#: src/snes9x.ui:923
-msgid "EPX Smooth"
-msgstr "EPX Smooth"
-
-# TODO: make not translatable because proper name
-#: src/snes9x.ui:926
-msgid "Blargg's NTSC"
-msgstr "Blargg's NTSC"
-
-# TODO: make not translatable because proper name
-#: src/snes9x.ui:929
-msgid "Scanlines"
-msgstr "Scanlines"
-
-# TODO: make not translatable because proper name
-#: src/snes9x.ui:932
-msgid "Simple2x"
-msgstr "Simple2x"
-
-# TODO: make not translatable because proper name
-#: src/snes9x.ui:935
-msgid "Simple3x"
-msgstr "Simple3x"
-
-# TODO: make not translatable because proper name
-#: src/snes9x.ui:938
-msgid "Simple4x"
-msgstr "Simple4x"
-
-#: src/snes9x.ui:949
+#: src/snes9x.ui:936
 msgid "8:7 Square pixels"
 msgstr "8:7 kwadratowe piksle"
 
-#: src/snes9x.ui:952
+#: src/snes9x.ui:939
 msgid "8:7 Square pixels, integer multiples"
 msgstr "8:7 kwadratowe piksle, całkowite wielokrotne"
 
-#: src/snes9x.ui:955
+#: src/snes9x.ui:942
 msgid "4:3 SNES correct aspect"
 msgstr "4:3 prawidłowy stosunek SNES"
 
-#: src/snes9x.ui:958
+#: src/snes9x.ui:945
 msgid "4:3 SNES correct aspect, integer multiples"
 msgstr "4:3 prawidłowy stosunek SNES, całkowite wielokrotne"
 
-#: src/snes9x.ui:961
+#: src/snes9x.ui:948
 msgid "8*8:7*7 NTSC"
 msgstr "8*8:7*7 NTSC"
 
-#: src/snes9x.ui:964
+#: src/snes9x.ui:951
 msgid "8*8:7*7 NTSC, integer multiples"
 msgstr "8*8:7*7 NTSC, całkowite wielokrotne"
 
-#: src/snes9x.ui:981
+#: src/snes9x.ui:968
 msgid "Merge adjacent pairs"
 msgstr "Zlewaj sąsiadujące pary"
 
-#: src/snes9x.ui:984
+#: src/snes9x.ui:971
 msgid "Output directly"
 msgstr "Wyświetlaj bezpośrednio"
 
-#: src/snes9x.ui:987
-msgid "Scale low-resolution screens"
+#: src/snes9x.ui:974
+msgid "Scale low‑resolution screens"
 msgstr "Skaluj ekrany niskiej rozdzielczości"
 
-#: src/snes9x.ui:998 src/snes9x.ui:1036
+#: src/snes9x.ui:985 src/snes9x.ui:1023
 msgid "1"
 msgstr "1"
 
-#: src/snes9x.ui:1001 src/snes9x.ui:1039
+#: src/snes9x.ui:988 src/snes9x.ui:1026
 msgid "2"
 msgstr "2"
 
-#: src/snes9x.ui:1004 src/snes9x.ui:1042
+#: src/snes9x.ui:991 src/snes9x.ui:1029
 msgid "3"
 msgstr "3"
 
-#: src/snes9x.ui:1007 src/snes9x.ui:1045
+#: src/snes9x.ui:994 src/snes9x.ui:1032
 msgid "4"
 msgstr "4"
 
-#: src/snes9x.ui:1010 src/snes9x.ui:1048
+#: src/snes9x.ui:997 src/snes9x.ui:1035
 msgid "5"
 msgstr "5"
 
-#: src/snes9x.ui:1013 src/snes9x.ui:1051
+#: src/snes9x.ui:1000 src/snes9x.ui:1038
 msgid "1+"
 msgstr "1+"
 
-#: src/snes9x.ui:1016 src/snes9x.ui:1054
+#: src/snes9x.ui:1003 src/snes9x.ui:1041
 msgid "2+"
 msgstr "2+"
 
-#: src/snes9x.ui:1019 src/snes9x.ui:1057
+#: src/snes9x.ui:1006 src/snes9x.ui:1044
 msgid "3+"
 msgstr "3+"
 
-#: src/snes9x.ui:1022 src/snes9x.ui:1060
+#: src/snes9x.ui:1009 src/snes9x.ui:1047
 msgid "4+"
 msgstr "4+"
 
-#: src/snes9x.ui:1025 src/snes9x.ui:1063
+#: src/snes9x.ui:1012 src/snes9x.ui:1050
 msgid "5+"
 msgstr "5+"
 
-#: src/snes9x.ui:1074
+#: src/snes9x.ui:1061
 msgid "Toggle the menu bar"
 msgstr "Przełącz listwę menu"
 
-#: src/snes9x.ui:1077
+#: src/snes9x.ui:1064
 msgid "Exit fullscreen mode"
 msgstr "Opuść tryb pełnoekranowy"
 
-#: src/snes9x.ui:1080 src/snes9x.ui:6957
+#: src/snes9x.ui:1067 src/snes9x.ui:6932
 msgid "Quit Snes9x"
 msgstr "Zakończ Snes9x"
 
-#: src/snes9x.ui:1091
-msgid "Timer-based"
+#: src/snes9x.ui:1078
+msgid "Timer‑based"
 msgstr "Zegar"
 
-#: src/snes9x.ui:1094
-msgid "Timer-based with automatic frame-skipping"
+#: src/snes9x.ui:1081
+msgid "Timer‑based with automatic frame-skipping"
 msgstr "Zegar z automatycznym pomijaniem klatek"
 
-#: src/snes9x.ui:1097
+#: src/snes9x.ui:1084
 msgid "Sound buffer synchronization"
 msgstr "Synchronizacja z buforem dźwięku"
 
-#: src/snes9x.ui:1100
+#: src/snes9x.ui:1087
 msgid "No throttling, use vsync to control speed"
 msgstr "Synchronizacja pionowa wyświetlacza"
 
-# TODO: Change to English number rendering and SI symbol
-#: src/snes9x.ui:1111
-msgid "48000 hz"
-msgstr "48 000 Hz"
+#: src/snes9x.ui:1098
+msgid "48,000 Hz"
+msgstr "48 000 Hz"
 
-# TODO: Change to English number rendering and SI symbol
-#: src/snes9x.ui:1114
-msgid "44100 hz"
-msgstr "44 100 Hz"
+#: src/snes9x.ui:1101
+msgid "44,100 Hz"
+msgstr "44 100 Hz"
 
-# TODO: Change to English number rendering and SI symbol
-#: src/snes9x.ui:1117
-msgid "32000 hz"
-msgstr "32 000 Hz"
+#: src/snes9x.ui:1104
+msgid "32,000 Hz"
+msgstr "32 000 Hz"
 
-# TODO: Change to English number rendering and SI symbol
-#: src/snes9x.ui:1120
-msgid "22050 hz"
-msgstr "22 050 Hz"
+#: src/snes9x.ui:1107
+msgid "22,050 Hz"
+msgstr "22 050 Hz"
 
-# TODO: Change to English number rendering and SI symbol
-#: src/snes9x.ui:1123
-msgid "16000 hz"
-msgstr "16 000 Hz"
+#: src/snes9x.ui:1110
+msgid "16,000 Hz"
+msgstr "16 000 Hz"
 
-# TODO: Change to English number rendering and SI symbol
-#: src/snes9x.ui:1126
-msgid "11025 hz"
-msgstr "11 025 Hz"
+#: src/snes9x.ui:1113
+msgid "11,025 Hz"
+msgstr "11 025 Hz"
 
-# TODO: Change to English number rendering and SI symbol
-#: src/snes9x.ui:1129
-msgid "8000 hz"
-msgstr "8 000 Hz"
+#: src/snes9x.ui:1116
+msgid "8,000 Hz"
+msgstr "8 000 Hz"
 
-# TODO: Change to English number rendering and SI symbol
-#: src/snes9x.ui:1132
-msgid "0 hz"
-msgstr "0 Hz"
+#: src/snes9x.ui:1119
+msgid "0 Hz"
+msgstr "0 Hz"
 
-#: src/snes9x.ui:1149
-msgid "16-bit (GL_RGB)"
+#: src/snes9x.ui:1136
+msgid "16‑bit (GL_RGB)"
 msgstr "16 bitów (GL_RGB)"
 
-#: src/snes9x.ui:1152
-msgid "32-bit (GL_BGRA)"
+#: src/snes9x.ui:1139
+msgid "32‑bit (GL_BGRA)"
 msgstr "32 bity (GL_BGRA)"
 
-#: src/snes9x.ui:1163
+#: src/snes9x.ui:1150
 msgid "Nearest"
 msgstr "Najbliższy"
 
-#: src/snes9x.ui:1166
+#: src/snes9x.ui:1153
 msgid "Linear"
 msgstr "Liniowy"
 
-#: src/snes9x.ui:1169
+#: src/snes9x.ui:1156
 msgid "Gaussian (correct)"
 msgstr "Gaussa (prawidłowy)"
 
-#: src/snes9x.ui:1172
+#: src/snes9x.ui:1159
 msgid "Cubic"
 msgstr "Sześcienny"
 
-#: src/snes9x.ui:1175
+#: src/snes9x.ui:1162
 msgid "Sinc"
 msgstr "Sinc"
 
-#: src/snes9x.ui:1188
+#: src/snes9x.ui:1175
 msgid "Snes9x"
 msgstr "Snes9x"
 
-#: src/snes9x.ui:1208
+#: src/snes9x.ui:1195
 msgid "_File"
 msgstr "_Plik"
 
-#: src/snes9x.ui:1215
-msgid "_Open ROM Image..."
+#: src/snes9x.ui:1202
+msgid "_Open ROM Image…"
 msgstr "_Otwórz obraz ROM…"
 
-#: src/snes9x.ui:1229
+#: src/snes9x.ui:1216
 msgid "Open Recent"
 msgstr "Otwórz os_tatnie"
 
-#: src/snes9x.ui:1238
+#: src/snes9x.ui:1225
 msgid "Clear Recent Items"
 msgstr "_Wyczyść listę ostatnich elementów"
 
-#: src/snes9x.ui:1250
-msgid "Open with _NetPlay..."
+#: src/snes9x.ui:1237
+msgid "Open with _NetPlay…"
 msgstr "Otwórz z _NetPlay…"
 
-#: src/snes9x.ui:1253
+#: src/snes9x.ui:1240
 msgid "Open a ROM to use with NetPlay"
 msgstr "Otwiera ROM z użyciem NetPlay"
 
-#: src/snes9x.ui:1264
-msgid "Open _MultiCart..."
+#: src/snes9x.ui:1251
+msgid "Open _MultiCart…"
 msgstr "Otwórz zestaw ROMów (_MultiCart)…"
 
-#: src/snes9x.ui:1279
+#: src/snes9x.ui:1266
 msgid "_Load State"
 msgstr "_Ładuj stan"
 
-#: src/snes9x.ui:1289 src/snes9x.ui:1423
+#: src/snes9x.ui:1276 src/snes9x.ui:1410
 msgid "Slot _0"
 msgstr "Miejsce _0"
 
-#: src/snes9x.ui:1298 src/snes9x.ui:1432
+#: src/snes9x.ui:1285 src/snes9x.ui:1419
 msgid "Slot _1"
 msgstr "Miejsce _1"
 
-#: src/snes9x.ui:1307 src/snes9x.ui:1441
+#: src/snes9x.ui:1294 src/snes9x.ui:1428
 msgid "Slot _2"
 msgstr "Miejsce _2"
 
-#: src/snes9x.ui:1316 src/snes9x.ui:1450
+#: src/snes9x.ui:1303 src/snes9x.ui:1437
 msgid "Slot _3"
 msgstr "Miejsce _3"
 
-#: src/snes9x.ui:1325 src/snes9x.ui:1459
+#: src/snes9x.ui:1312 src/snes9x.ui:1446
 msgid "Slot _4"
 msgstr "Miejsce _4"
 
-#: src/snes9x.ui:1334 src/snes9x.ui:1468
+#: src/snes9x.ui:1321 src/snes9x.ui:1455
 msgid "Slot _5"
 msgstr "Miejsce _5"
 
-#: src/snes9x.ui:1343 src/snes9x.ui:1477
+#: src/snes9x.ui:1330 src/snes9x.ui:1464
 msgid "Slot _6"
 msgstr "Miejsce _6"
 
-#: src/snes9x.ui:1352 src/snes9x.ui:1486
+#: src/snes9x.ui:1339 src/snes9x.ui:1473
 msgid "Slot _7"
 msgstr "Miejsce _7"
 
-#: src/snes9x.ui:1361 src/snes9x.ui:1495
+#: src/snes9x.ui:1348 src/snes9x.ui:1482
 msgid "Slot _8"
 msgstr "Miejsce _8"
 
-#: src/snes9x.ui:1370 src/snes9x.ui:1504
+#: src/snes9x.ui:1357 src/snes9x.ui:1491
 msgid "Slot _9"
 msgstr "Miejsce _9"
 
-#: src/snes9x.ui:1385
-msgid "From _File..."
+#: src/snes9x.ui:1372
+msgid "From _File…"
 msgstr "Z _pliku…"
 
-#: src/snes9x.ui:1400
+#: src/snes9x.ui:1387
 msgid "_Undo Load State"
 msgstr "_Cofnij załadowany stan"
 
-#: src/snes9x.ui:1413
+#: src/snes9x.ui:1400
 msgid "_Save State"
 msgstr "_Zapisz stan"
 
-#: src/snes9x.ui:1519
-msgid "To _File..."
+#: src/snes9x.ui:1506
+msgid "To _File…"
 msgstr "Do _pliku…"
 
-#: src/snes9x.ui:1536
-msgid "Save SPC..."
-msgstr "Zapisz _SPC…"
+#: src/snes9x.ui:1523
+msgid "Save SPC…"
+msgstr "Zapisz SPC"
 
-#: src/snes9x.ui:1553
-msgid "Show ROM _Info..."
+#: src/snes9x.ui:1540
+msgid "Show ROM _Info…"
 msgstr "Wyświetl _info o ROMie…"
 
-#: src/snes9x.ui:1570
-msgid "_Quit"
-msgstr "_Zakończ"
+#: src/snes9x.ui:1557
+msgid "gtk-quit"
+msgstr "gtk-quit"
 
-#: src/snes9x.ui:1587
+#: src/snes9x.ui:1571
 msgid "_Emulation"
 msgstr "_Emulacja"
 
-#: src/snes9x.ui:1594
+#: src/snes9x.ui:1578
 msgid "Run / _Continue"
 msgstr "_Uruchom/kontynuuj"
 
-#: src/snes9x.ui:1605
+#: src/snes9x.ui:1589
 msgid "_Pause"
 msgstr "_Przerwij"
 
-#: src/snes9x.ui:1623
-msgid "Load _Movie..."
-msgstr "_Ładuj wideo…"
+#: src/snes9x.ui:1607
+msgid "Load _Movie…"
+msgstr "Załaduj wideo"
 
-#: src/snes9x.ui:1635
-msgid "R_ecord Movie..."
+#: src/snes9x.ui:1619
+msgid "R_ecord Movie…"
 msgstr "_Nagraj wideo…"
 
-#: src/snes9x.ui:1647
+#: src/snes9x.ui:1631
 msgid "_Stop Recording"
 msgstr "Za_trzymaj nagrywanie"
 
-#: src/snes9x.ui:1659
-msgid "_Jump to Frame..."
+#: src/snes9x.ui:1643
+msgid "_Jump to Frame…"
 msgstr "S_kocz do klatki…"
 
-#: src/snes9x.ui:1677
+#: src/snes9x.ui:1661
 msgid "Sy_nc Clients"
 msgstr "Z_synchronizuj klientów"
 
-#: src/snes9x.ui:1694
+#: src/snes9x.ui:1678
 msgid "Reset"
 msgstr "Uruchom SNESa _ponownie"
 
-#: src/snes9x.ui:1706
+#: src/snes9x.ui:1690
 msgid "Soft _Reset"
 msgstr "Uruchom _ROM ponownie"
 
-#: src/snes9x.ui:1723
+#: src/snes9x.ui:1707
 msgid "_View"
 msgstr "_Widok"
 
-#: src/snes9x.ui:1731
+#: src/snes9x.ui:1715
 msgid "_Toggle Menubar"
 msgstr "Przełącz listwę _menu"
 
-#: src/snes9x.ui:1748
+#: src/snes9x.ui:1732
 msgid "_Change Size"
 msgstr "Zmień _rozmiar"
 
-#: src/snes9x.ui:1762
-msgid "_1x"
+#: src/snes9x.ui:1746
+msgid "_1×"
 msgstr "_1×"
 
-#: src/snes9x.ui:1771
-msgid "_2x"
+#: src/snes9x.ui:1755
+msgid "_2×"
 msgstr "_2×"
 
-#: src/snes9x.ui:1780
-msgid "_3x"
+#: src/snes9x.ui:1764
+msgid "_3×"
 msgstr "_3×"
 
-#: src/snes9x.ui:1789
-msgid "_4x"
+#: src/snes9x.ui:1773
+msgid "_4×"
 msgstr "_4×"
 
-#: src/snes9x.ui:1798
-msgid "_5x"
+#: src/snes9x.ui:1782
+msgid "_5×"
 msgstr "_5×"
 
-#: src/snes9x.ui:1807
-msgid "_6x"
+#: src/snes9x.ui:1791
+msgid "_6×"
 msgstr "_6×"
 
-#: src/snes9x.ui:1816
-msgid "_7x"
+#: src/snes9x.ui:1800
+msgid "_7×"
 msgstr "_7×"
 
-#: src/snes9x.ui:1825
-msgid "_8x"
+#: src/snes9x.ui:1809
+msgid "_8×"
 msgstr "_8×"
 
-#: src/snes9x.ui:1834
-msgid "_9x"
+#: src/snes9x.ui:1818
+msgid "_9×"
 msgstr "_9×"
 
-#: src/snes9x.ui:1843
-msgid "1_0x"
+#: src/snes9x.ui:1827
+msgid "1_0×"
 msgstr "1_0×"
 
-#: src/snes9x.ui:1860
-msgid "_Fullscreen"
-msgstr "Pełny _ekran"
+#: src/snes9x.ui:1844
+msgid "gtk-fullscreen"
+msgstr "gtk-fullscreen"
 
-#: src/snes9x.ui:1877
+#: src/snes9x.ui:1858
 msgid "_Options"
 msgstr "_Opcje"
 
-#: src/snes9x.ui:1886
+#: src/snes9x.ui:1867
 msgid "Controller Ports"
 msgstr "_Gniazda kontrolerów"
 
-#: src/snes9x.ui:1895
+#: src/snes9x.ui:1876
 msgid "SNES Port 1"
 msgstr "Gniazdo _1 SNESa"
 
-#: src/snes9x.ui:1905 src/snes9x.ui:1949
+#: src/snes9x.ui:1886 src/snes9x.ui:1930
 msgid "Joypad"
 msgstr "_Kontroler"
 
-#: src/snes9x.ui:1914 src/snes9x.ui:1958
+#: src/snes9x.ui:1895 src/snes9x.ui:1939
 msgid "Mouse"
 msgstr "_Mysz"
 
-#: src/snes9x.ui:1924 src/snes9x.ui:1978
+#: src/snes9x.ui:1905 src/snes9x.ui:1959
 msgid "Superscope"
 msgstr "_Superscope"
 
-#: src/snes9x.ui:1939
+#: src/snes9x.ui:1920
 msgid "SNES Port 2"
 msgstr "Gniazdo _2 SNESa"
 
-#: src/snes9x.ui:1968
+#: src/snes9x.ui:1949
 msgid "Multitap"
 msgstr "M_ultitap"
 
-#: src/snes9x.ui:2015
-msgid "_Cheats..."
+#: src/snes9x.ui:1970
+msgctxt "SNES port 2"
+msgid "None"
+msgstr "Brak"
+
+#: src/snes9x.ui:1996
+msgid "_Cheats…"
 msgstr "_Cheaty…"
 
-#: src/snes9x.ui:2029
-msgid "_Shader Parameters..."
-msgstr "Parametry cie_niowania…"
+#: src/snes9x.ui:2010
+msgid "_Shader Parameters…"
+msgstr "_Parametry cieniowania…"
 
-#: src/snes9x.ui:2045
-msgid "_Preferences..."
-msgstr "_Preferencje…"
+#: src/snes9x.ui:2026
+msgid "gtk-preferences"
+msgstr "gtk-preferences"
 
-#: src/snes9x.ui:2090
+#: src/snes9x.ui:2068
 msgid "Open Multiple ROM Images (MultiCart)"
 msgstr "Otwieranie zestawu obrazów ROM (MultiCart)"
 
-#: src/snes9x.ui:2153
+#: src/snes9x.ui:2131
 msgid "Slot A:"
 msgstr "Miejsce A:"
 
-#: src/snes9x.ui:2165
+#: src/snes9x.ui:2143
 msgid "Select an Image for Slot A"
 msgstr "Markowanie obrazu na miejsce A"
 
-#: src/snes9x.ui:2189
+#: src/snes9x.ui:2167
 msgid "Slot B:"
 msgstr "Miejsce B:"
 
-#: src/snes9x.ui:2201
+#: src/snes9x.ui:2179
 msgid "Select an Image for Slot B"
 msgstr "Markowanie obrazu na miejsce B"
 
-#: src/snes9x.ui:2233
+#: src/snes9x.ui:2211
 msgid "Snes9x NetPlay"
 msgstr "Snes9x NetPlay"
 
-#: src/snes9x.ui:2310
+#: src/snes9x.ui:2288
 msgid ""
 "The game chosen will be loaded before connecting. This field can be blank if "
 "the server will send the ROM image"
@@ -934,49 +894,48 @@ msgstr ""
 "Tu wskazana gra zostanie załadowana przed połączeniem. Pole to może pozostać "
 "puste, jeśli serwer przyśle obraz ROM."
 
-#: src/snes9x.ui:2325 src/snes9x.ui:4022 src/snes9x.ui:5137 src/snes9x.ui:5152
-#: src/snes9x.ui:5169 src/snes9x.ui:5186 src/snes9x.ui:5203
-msgid "Browse..."
+#: src/snes9x.ui:2303 src/snes9x.ui:4001 src/snes9x.ui:5116 src/snes9x.ui:5131
+#: src/snes9x.ui:5148 src/snes9x.ui:5165 src/snes9x.ui:5182
+msgid "Browse…"
 msgstr "Przeglądaj…"
 
-#: src/snes9x.ui:2347
+#: src/snes9x.ui:2325
 msgid "Clear entry"
 msgstr "Wyczyść wpis"
 
-#: src/snes9x.ui:2367
+#: src/snes9x.ui:2345
 msgid "<b>ROM Image</b>"
 msgstr "<b>Obraz ROM</b>"
 
-#: src/snes9x.ui:2396
+#: src/snes9x.ui:2374
 msgid "Connect to another computer"
 msgstr "Połącz z innym komputerem"
 
-#: src/snes9x.ui:2400
+#: src/snes9x.ui:2378
 msgid "Connect to another computer that is running Snes9x NetPlay as a server"
 msgstr "Łączy z innym komputerem, który uruchomił Snes9x NetPlay jako serwer."
 
-#: src/snes9x.ui:2420
+#: src/snes9x.ui:2398
 msgid "Name or IP address:"
 msgstr "Nazwa lub adres IP"
 
-#: src/snes9x.ui:2432
+#: src/snes9x.ui:2410
 msgid "Domain name or internet protocol address of a remote computer"
 msgstr "Nazwa domeny lub adres protokołu internetowego oddalonego komputera."
 
-#: src/snes9x.ui:2448
+#: src/snes9x.ui:2426
 msgid "Port:"
 msgstr "Gniazdo:"
 
-# TODO: Falsely used twice for TCP remote port and on‑screen display size
-#: src/snes9x.ui:2460 src/snes9x.ui:2930
+#: src/snes9x.ui:2438
 msgid "Connect to specified TCP port on remote computer"
 msgstr "Łączy z podanym gniazdem TCP na oddalonym komputerze."
 
-#: src/snes9x.ui:2485
+#: src/snes9x.ui:2463
 msgid "Act as a server"
 msgstr "Bądź serwerem"
 
-#: src/snes9x.ui:2489
+#: src/snes9x.ui:2467
 msgid ""
 "Host a game on this computer as Player 1, requiring extra throughput to "
 "support multitple users"
@@ -984,15 +943,15 @@ msgstr ""
 "Prowadzi grę na tym komputerze jako gracz 1, wymagając dodatkowej "
 "przepustowości aby obsłużyć wielu użytkowników."
 
-#: src/snes9x.ui:2509
+#: src/snes9x.ui:2487
 msgid "<b>Server</b>"
 msgstr "<b>Serwer</b>"
 
-#: src/snes9x.ui:2539
+#: src/snes9x.ui:2517
 msgid "Sync using reset"
 msgstr "Synchronizuj uruchamiając ponownie"
 
-#: src/snes9x.ui:2543
+#: src/snes9x.ui:2521
 msgid ""
 "Reset the game when players join instead of transferring potentially "
 "unreliable freeze states"
@@ -1000,11 +959,11 @@ msgstr ""
 "Uruchamia grę ponownie gdy gracze przystępują do gry, zamiast przesyłać "
 "potencjalnie zawodne zapisy stanów."
 
-#: src/snes9x.ui:2554
+#: src/snes9x.ui:2532
 msgid "Send ROM image to clients"
 msgstr "Wysyłaj obraz ROM do klientów"
 
-#: src/snes9x.ui:2558
+#: src/snes9x.ui:2536
 msgid ""
 "Send the running game image to players instead of requiring them to have "
 "their own copies"
@@ -1012,216 +971,210 @@ msgstr ""
 "Wysyła obraz uruchomionej gry do graczy, nie wymagając od nich posiadanie "
 "własnych kopii."
 
-#: src/snes9x.ui:2576
+#: src/snes9x.ui:2554
 msgid "Default port:"
 msgstr "Gniazdo domyślne:"
 
-#: src/snes9x.ui:2588
+#: src/snes9x.ui:2566
 msgid "TCP port used as a connection point for remote clients"
 msgstr "Gniazdo TCP używane jako punkt połączenia ze zdalnymi klientami."
 
-#: src/snes9x.ui:2620
+#: src/snes9x.ui:2598
 msgid "Ask server to pause when"
 msgstr "Domagaj się przerwy od serwera gdy opóźniony o"
 
-# TODO: convert to plurals
-#: src/snes9x.ui:2650
-msgid "frames behind"
-msgstr "klatek"
-
-#: src/snes9x.ui:2673
+#: src/snes9x.ui:2652
 msgid "<b>Settings</b>"
 msgstr "<b>Ustawienia</b>"
 
-#: src/snes9x.ui:2701
+#: src/snes9x.ui:2680
 msgid "Snes9x Preferences"
 msgstr "Preferencje Snes9x"
 
-#: src/snes9x.ui:2817
+#: src/snes9x.ui:2796
 msgid "Use fullscreen on ROM open"
 msgstr "Otwieraj ROM w trybie pełnoekranowym"
 
-#: src/snes9x.ui:2821
+#: src/snes9x.ui:2800
 msgid "Go to fullscreen mode immediately after opening a ROM"
 msgstr "Natychmiast po otwarciu ROMu przechodzi w tryb pełnoekranowy."
 
-#: src/snes9x.ui:2833
+#: src/snes9x.ui:2812
 msgid "Show local time"
 msgstr "Wyświetlaj czas lokalny"
 
-#: src/snes9x.ui:2848
+#: src/snes9x.ui:2827
 msgid "Show frame rate"
 msgstr "Wyświetlaj częstotliwość klatek"
 
-#: src/snes9x.ui:2863
+#: src/snes9x.ui:2842
 msgid "Show pressed keys"
 msgstr "Wyświetlaj naciśnięte klawisze"
 
-#: src/snes9x.ui:2878
-msgid "Show fast-forward and pause indicators"
+#: src/snes9x.ui:2857
+msgid "Show fast‑forward and pause indicators"
 msgstr "Wyświetlaj wskaźniki przewijania i przerwy"
 
-#: src/snes9x.ui:2893
+#: src/snes9x.ui:2872
 msgid "Use overscanned height"
 msgstr "Używaj wysokość poza obszarem wyświetlania"
 
-#: src/snes9x.ui:2897
+#: src/snes9x.ui:2876
 msgid "Use SNES extended height. Will probably cause letterboxing"
 msgstr ""
 "Korzysta z rozszerzonej wysokości SNESa. Prawdopodobnie spowoduje kadrowanie."
 
-#: src/snes9x.ui:2919
-msgid "On-screen display size:"
-msgstr "Rozmiar komunikatów na ekranie:"
+#: src/snes9x.ui:2898
+msgid "On‑screen display size:"
+msgstr "Rozmiar wyświetlanych komunikatów na ekranie:"
 
-#: src/snes9x.ui:2961
+#: src/snes9x.ui:2909
+msgid "The size of on‑screen display messages in pixels"
+msgstr "Rozmiar w pikslach komunikatów wyświetlanych na ekranie"
+
+#: src/snes9x.ui:2940
 msgid "Change fullscreen resolution:"
-msgstr "Zmień rozdzielczość pełnego ekranu:"
+msgstr "Zmieniaj rozdzielczość pełnego ekranu:"
 
-#: src/snes9x.ui:2965
+#: src/snes9x.ui:2944
 msgid "Changes the screen resolution when running Snes9x in fullscreen mode"
 msgstr ""
 "Zmienia rozdzielczość ekranu gdy Snes9x pracuje w trybie pełnoekranowym."
 
-#: src/snes9x.ui:3010
+#: src/snes9x.ui:2989
 msgid "Basic Settings"
 msgstr "Ustawienia podstawowe"
 
-#: src/snes9x.ui:3051
+#: src/snes9x.ui:3030
 msgid "Scale image to fit window"
 msgstr "Skaluj obraz do rozmiaru okna"
 
-#: src/snes9x.ui:3055
+#: src/snes9x.ui:3034
 msgid "Scales the image so no black bars are present"
 msgstr "Skaluje obraz, aby zapobiec kadrowaniu."
 
-#: src/snes9x.ui:3075
+#: src/snes9x.ui:3054
 msgid "Aspect ratio:"
 msgstr "Stosunek stron:"
 
-#: src/snes9x.ui:3110
-msgid "Maintain aspect-ratio"
+#: src/snes9x.ui:3089
+msgid "Maintain aspect ratio"
 msgstr "Zachowuj stosunek stron"
 
-#: src/snes9x.ui:3114
+#: src/snes9x.ui:3093
 msgid "Scales the image as large as possible without distortion"
 msgstr "Skaluje obraz do największego możliwego rozmiaru bez zniekształcenia."
 
-#: src/snes9x.ui:3131
-msgid "Use "
-msgstr "Używaj "
-
-#: src/snes9x.ui:3135
+#: src/snes9x.ui:3108
 msgid "Allows scaling and filtering to use multiple processors"
 msgstr "Umożliwia wykorzystanie wielu procesorów do skalowania i filtrowania."
 
-# TODO: convert to plurals
-#: src/snes9x.ui:3167
-msgid "threads for filtering and scaling"
-msgstr "wątków do filtrowania i skalowania"
+#: src/snes9x.ui:3111
+msgid "Use"
+msgstr "Używaj"
 
-#: src/snes9x.ui:3191
-msgid "High-resolution effect:"
+#: src/snes9x.ui:3170
+msgid "High‑resolution effect:"
 msgstr "Efekt wysokiej rozdzielczości:"
 
-#: src/snes9x.ui:3234
+#: src/snes9x.ui:3213
 msgid "Apply scaling filter:"
 msgstr "Stosuj filtr skalowania:"
 
-#: src/snes9x.ui:3302
+#: src/snes9x.ui:3281
 msgid "Video preset:"
 msgstr "Profil wideo:"
 
-#: src/snes9x.ui:3316
+#: src/snes9x.ui:3295
 msgid "Composite"
 msgstr "Zespolony"
 
-#: src/snes9x.ui:3330
-msgid "S-Video"
+#: src/snes9x.ui:3309
+msgid "S‑Video"
 msgstr "S‑wideo"
 
-#: src/snes9x.ui:3344
+#: src/snes9x.ui:3323
 msgid "RGB"
 msgstr "RGB"
 
-#: src/snes9x.ui:3358
+#: src/snes9x.ui:3337
 msgid "Monochrome"
 msgstr "Monochromowy"
 
-#: src/snes9x.ui:3399
+#: src/snes9x.ui:3378
 msgid "Artifacts:"
 msgstr "Artefakty:"
 
-#: src/snes9x.ui:3414
+#: src/snes9x.ui:3393
 msgid "Sharpness:"
 msgstr "Ostrość:"
 
-#: src/snes9x.ui:3429
+#: src/snes9x.ui:3408
 msgid "Brightness:"
 msgstr "Jasność:"
 
-#: src/snes9x.ui:3444
+#: src/snes9x.ui:3423
 msgid "Contrast:"
 msgstr "Kontrast:"
 
-#: src/snes9x.ui:3459
+#: src/snes9x.ui:3438
 msgid "Saturation:"
 msgstr "Nasycenie:"
 
-#: src/snes9x.ui:3474
+#: src/snes9x.ui:3453
 msgid "Hue:"
 msgstr "Barwa:"
 
-#: src/snes9x.ui:3675
+#: src/snes9x.ui:3654
 msgid "Gamma:"
 msgstr "Gamma:"
 
-#: src/snes9x.ui:3690
+#: src/snes9x.ui:3669
 msgid "Fringing:"
 msgstr "Frędzlowanie:"
 
-#: src/snes9x.ui:3705
+#: src/snes9x.ui:3684
 msgid "Bleed:"
 msgstr "Wyciek:"
 
-#: src/snes9x.ui:3720
+#: src/snes9x.ui:3699
 msgid "Resolution:"
 msgstr "Rozdzielczość:"
 
-#: src/snes9x.ui:3750
+#: src/snes9x.ui:3729
 msgid "Merge odd and even fields"
 msgstr "Zlewaj parzyste i nieparzyste pola"
 
-#: src/snes9x.ui:3772 src/snes9x.ui:3831
+#: src/snes9x.ui:3751 src/snes9x.ui:3810
 msgid "Scanline intensity:"
 msgstr "Intensywność linii badania:"
 
-#: src/snes9x.ui:3876
+#: src/snes9x.ui:3855
 msgid "Scaling"
 msgstr "Skalowanie"
 
-#: src/snes9x.ui:3918
-msgid "Bilinear-filter output"
+#: src/snes9x.ui:3897
+msgid "Bilinear‐filter output"
 msgstr "Filtruj _dwuliniowo sygnał wyjściowy"
 
-#: src/snes9x.ui:3933
-msgid "Use best settings for FreeSync/G-Sync when fullscreen"
-msgstr "Najlepsze ustawienia _FreeSync/G-Sync w trybie pełnoekranowym"
+#: src/snes9x.ui:3912
+msgid "Use best settings for FreeSync/G‑Sync when in fullscreen"
+msgstr "Najlepsze ustawienia _FreeSync/G‑Sync w trybie pełnoekranowym"
 
-#: src/snes9x.ui:3954
+#: src/snes9x.ui:3933
 msgid "Sync to vertical blank"
 msgstr "_Synchronizuj z luką pionową"
 
-#: src/snes9x.ui:3958
+#: src/snes9x.ui:3937
 msgid "Sync the image to the vertical retrace to stop tearing"
 msgstr ""
 "Synchronizuje obraz z pionowym powrotem, aby zapobiec rozdzieraniu obrazu."
 
-#: src/snes9x.ui:3970
+#: src/snes9x.ui:3949
 msgid "Reduce input lag"
 msgstr "_Redukuj opóźnienie sterowania"
 
-#: src/snes9x.ui:3974
+#: src/snes9x.ui:3953
 msgid ""
 "Sync the program with the video output after every displayed frame to reduce "
 "input latency"
@@ -1229,141 +1182,131 @@ msgstr ""
 "Synchronizuje program z wyjściem wideo po każdej wyświetlonej klatce, aby "
 "zredukować opóźnienie sterowania."
 
-#: src/snes9x.ui:3990
+#: src/snes9x.ui:3969
 msgid "Shader:"
 msgstr "_Cieniownik:"
 
-#: src/snes9x.ui:4054
-msgid "Force an inverted byte-ordering"
+#: src/snes9x.ui:4033
+msgid "Force an inverted byte‑ordering"
 msgstr "Wymuszaj odwróconą kolejność bajtów"
 
-#: src/snes9x.ui:4058
+#: src/snes9x.ui:4037
 msgid ""
-"Forces a swapped byte-ordering for cases where the system's endian is used "
+"Forces a swapped byte‑ordering for cases where the system’s endian is used "
 "instead of the video card"
 msgstr ""
 "Wymusza wymienioną kolejność bajtów w przypadkach, gdy używana jest końcowość "
 "bajtów systemu zamiast karty graficznej."
 
-#: src/snes9x.ui:4082
+#: src/snes9x.ui:4061
 msgid "Hardware Acceleration"
 msgstr "Przyśpieszenie sprzętowe"
 
-#: src/snes9x.ui:4111
+#: src/snes9x.ui:4090
 msgid "Display"
 msgstr "_Wyświetlacz"
 
-#: src/snes9x.ui:4164
+#: src/snes9x.ui:4143
 msgid "Sound driver:"
 msgstr "_Sterownik dźwięku:"
 
-#: src/snes9x.ui:4199
+#: src/snes9x.ui:4178
 msgid "Automatically adjust input rate to display"
 msgstr "Automatycznie dopasowuj częstotliwość wejściową do wyświetlacza"
 
-#: src/snes9x.ui:4203
-msgid "Sets the correct input rate based on the display's refresh rate"
+#: src/snes9x.ui:4182
+msgid "Sets the correct input rate based on the display’s refresh rate"
 msgstr ""
 "Ustawia prawidłową częstotliwość wejściową na podstawie częstotliwości "
 "odświeżania wyświetlacza."
 
-#: src/snes9x.ui:4215
+#: src/snes9x.ui:4194
 msgid "Dynamic rate control"
 msgstr "_Dynamicznie steruj częstotliwością"
 
-#: src/snes9x.ui:4219
+#: src/snes9x.ui:4198
 msgid "Smooth out slight hiccups in sound input rate"
 msgstr "Wygładza niewielkie zacięcia w częstotliwości wejściowej dźwięku."
 
-#: src/snes9x.ui:4230
+#: src/snes9x.ui:4209
 msgid "Mute sound output"
 msgstr "Wyciszaj wydawanie dźwięku"
 
-#: src/snes9x.ui:4234
+#: src/snes9x.ui:4213
 msgid "Disables output of sound"
 msgstr "Wyłącza wydawanie dźwięku."
 
-#: src/snes9x.ui:4246
+#: src/snes9x.ui:4225
 msgid "Mute sound when using turbo or rewind"
 msgstr "Wyciszaj dźwięk podczas używania turbo lub odwijania"
 
-#: src/snes9x.ui:4250
+#: src/snes9x.ui:4229
 msgid "Disables output of sound when using turbo or rewind"
 msgstr "Wyłącza wydawanie dźwięku podczas użycia turbo lub odwijania."
 
-#: src/snes9x.ui:4273
+#: src/snes9x.ui:4252
 msgid "Playback rate:"
 msgstr "Częstotliwość odtwarzania:"
 
-# TODO: convert to plurals
-#: src/snes9x.ui:4308
-msgid "milliseconds"
-msgstr "ms"
-
-#: src/snes9x.ui:4331
+#: src/snes9x.ui:4310
 msgid "Buffer size:"
 msgstr "Rozmiar bufora:"
 
-#: src/snes9x.ui:4345
+#: src/snes9x.ui:4324
 msgid "Dynamic rate limit:"
 msgstr "Dynamiczne ograniczenie częstotliwości:"
 
-#: src/snes9x.ui:4390
+#: src/snes9x.ui:4369
 msgid "Input rate:"
 msgstr "Częstotliwość wejściowa:"
 
-#: src/snes9x.ui:4403
+#: src/snes9x.ui:4382
 msgid ""
 "Adjust to produce more or less data. Decrease the rate if experiencing "
-"crackling. Increase the rate if experiencing frame-rate stuttering. Best used "
-"with the \"Synchronize with sound\" option"
+"crackling. Increase the rate if experiencing frame rate stuttering. Best used "
+"with the “Sound buffer synchronization” option."
 msgstr ""
 "Dopasuj ilość produkowanych danych. Pomniejsz częstotliwość, jeśli "
 "doświadczasz trzeszczenia dźwięku. Powiększ częstotliwość, jeśli doświadczasz "
 "drganie klatek. Najlepiej współdziała z opcją „Zsynchronizuj z dźwiękiem”."
 
-#: src/snes9x.ui:4452
+#: src/snes9x.ui:4432
 msgid "Video rate:"
 msgstr "Częstotliwość wideo:"
 
-# TODO: remove
-#: src/snes9x.ui:4465
-msgid "label"
-msgstr "label"
-
-#: src/snes9x.ui:4490
+#: src/snes9x.ui:4469
 msgid "<b>Sound Settings</b>"
 msgstr "<b>Ustawienia dźwięku</b>"
 
-#: src/snes9x.ui:4524 src/snes9x.ui:8755
+#: src/snes9x.ui:4503 src/snes9x.ui:8730
 msgid "Sound"
 msgstr "_Dźwięk"
 
-#: src/snes9x.ui:4582
+#: src/snes9x.ui:4561
 msgid "Throttling method:"
 msgstr "Metoda pomiaru czasu:"
 
-#: src/snes9x.ui:4624
+#: src/snes9x.ui:4603
 msgid "<b>Speed Control</b>"
 msgstr "<b>Sterowanie prędkością</b>"
 
-#: src/snes9x.ui:4662
+#: src/snes9x.ui:4641
 msgid "Rewind buffer size (MB):"
 msgstr "Rozmiar bufora odwijania w MB:"
 
-#: src/snes9x.ui:4704
+#: src/snes9x.ui:4683
 msgid "Number of frames between rewind snapshots:"
 msgstr "Ilość klatek między rejestracjami odwijania:"
 
-#: src/snes9x.ui:4745
+#: src/snes9x.ui:4724
 msgid "<b>Rewind Settings</b>"
 msgstr "<b>Ustawienia odwijania</b>"
 
-#: src/snes9x.ui:4776
+#: src/snes9x.ui:4755
 msgid "Allow invalid VRAM access"
 msgstr "Zezwalaj na nieprawidłowy dostęp do pamięci roboczej wideo (VRAM)"
 
-#: src/snes9x.ui:4780
+#: src/snes9x.ui:4759
 msgid ""
 "Allows ROM hacks to write to screen at the wrong time. Only use if you know "
 "your ROM hack expects this"
@@ -1371,522 +1314,515 @@ msgstr ""
 "Zezwala hakom ROMów rysować na ekranie w nieprawidłowym czasie. Używaj "
 "wyłącznie gdy masz pewność, że Twój hak ROMu tego potrzebuje."
 
-#: src/snes9x.ui:4790
+#: src/snes9x.ui:4769
 msgid "Allow opposing dpad directions"
 msgstr "Zezwalaj na przeciwnie kierunki krzyżaka"
 
-#: src/snes9x.ui:4794
+#: src/snes9x.ui:4773
 msgid "Let left and right or up and down be pressed at the same time"
 msgstr "Dopuszcza naciśnięcie ↔ lub ↕ równocześnie."
 
-#: src/snes9x.ui:4805
+#: src/snes9x.ui:4784
 msgid "Overclock CPU"
 msgstr "Nie limituj prędkości CPU SNESa"
 
-#: src/snes9x.ui:4809
+#: src/snes9x.ui:4788
 msgid "Reduces slowdown, but has potential to break games"
 msgstr "Redukuje spowolnienia, lecz może potencjalnie psuć gry."
 
-#: src/snes9x.ui:4820
+#: src/snes9x.ui:4799
 msgid "Remove sprite limit"
 msgstr "Nie limituj ilości spriteów"
 
-#: src/snes9x.ui:4824
+#: src/snes9x.ui:4803
 msgid "Reduces flicker, but may cause graphical artifacts"
 msgstr "Redukuje migotanie, ale może powodować artefakty graficzne."
 
-#: src/snes9x.ui:4835
+#: src/snes9x.ui:4814
 msgid "Redirect echo buffer overflow"
 msgstr "Przekieruj nadmiar bufora echa"
 
-#: src/snes9x.ui:4839
+#: src/snes9x.ui:4818
 msgid "Allows old addmusic hacks to work, but will likely hurt other games"
 msgstr ""
 "Umożliwia funkcjonowanie starych haków „addmusic”, lecz prawdopodobnie "
 "zaszkodzi innym grom."
 
-#: src/snes9x.ui:4857
+#: src/snes9x.ui:4836
 msgid "SuperFX clock speed %:"
 msgstr "Procent prędkości zegara SuperFXa:"
 
-#: src/snes9x.ui:4896
+#: src/snes9x.ui:4875
 msgid "Gaussian is the correct behavior for SNES hardware"
 msgstr "Filtr „Gaussa” odpowiada prawidłowemu zachowaniu osprzętu SNESa"
 
-#: src/snes9x.ui:4903
+#: src/snes9x.ui:4882
 msgid "Sound filter:"
 msgstr "Filtr dźwięku:"
 
-#: src/snes9x.ui:4940
+#: src/snes9x.ui:4919
 msgid "<b>Hacks</b>"
 msgstr "<b>Haki</b>"
 
-#: src/snes9x.ui:4982 src/snes9x.ui:7172
+#: src/snes9x.ui:4961 src/snes9x.ui:7147
 msgid "Emulation"
 msgstr "_Emulacja"
 
-#: src/snes9x.ui:5223
+#: src/snes9x.ui:5202
 msgid "SRAM:"
 msgstr "SRAM:"
 
-#: src/snes9x.ui:5235
+#: src/snes9x.ui:5214
 msgid "Save states:"
 msgstr "Zapis stanów:"
 
-#: src/snes9x.ui:5249
+#: src/snes9x.ui:5228
 msgid "Cheats:"
 msgstr "Cheaty:"
 
-#: src/snes9x.ui:5263
+#: src/snes9x.ui:5242
 msgid "Patches:"
 msgstr "Łatki:"
 
-#: src/snes9x.ui:5277
+#: src/snes9x.ui:5256
 msgid "Exports:"
 msgstr "Eksporty:"
 
-#: src/snes9x.ui:5301
+#: src/snes9x.ui:5280
 msgid "<b>Game Data Locations</b>"
 msgstr "<b>Położenia danych gry</b>"
 
-#: src/snes9x.ui:5334
+#: src/snes9x.ui:5313
 msgid "Save SRAM:"
 msgstr "Zapisz SRAM:"
 
-#: src/snes9x.ui:5346
+#: src/snes9x.ui:5325
 msgid ""
-"Automatically save the game's SRAM at this interval. Setting this to 0 will "
+"Automatically save the game’s SRAM at this interval. Setting this to 0 will "
 "only save when quitting or changing ROMs"
 msgstr ""
 "Automatycznie zapisuje SRAM gry w określonym interwale. Gdy 0, zapisuje "
 "wyłącznie przy zakończeniu Snes9x lub zmianie ROMu."
 
-# TODO: change to plurals
-#: src/snes9x.ui:5365
-msgid "seconds after change"
-msgstr "sekund po zmianie"
-
-#: src/snes9x.ui:5381
+#: src/snes9x.ui:5355
 msgid "<b>Automatic Saving</b>"
 msgstr "<b>Automatyczne zapisywanie</b>"
 
-#: src/snes9x.ui:5418
+#: src/snes9x.ui:5392
 msgid "Files"
 msgstr "_Pliki"
 
-#: src/snes9x.ui:5449
+#: src/snes9x.ui:5423
 msgid "<b>Joypad:</b>"
 msgstr "<b>Kontroler:</b>"
 
-#: src/snes9x.ui:5490
+#: src/snes9x.ui:5464
 msgid "_Reset"
 msgstr "Wy_zeruj"
 
-#: src/snes9x.ui:5518
+#: src/snes9x.ui:5492
 msgid "Swap with:"
 msgstr "Wymień na:"
 
-#: src/snes9x.ui:5546
+#: src/snes9x.ui:5520
 msgid "_Swap"
 msgstr "_Wymień"
 
-#: src/snes9x.ui:5568
-msgid "Use modifier keys (CTRL, SHIFT, ALT) directly"
-msgstr ""
-"Używaj klawisze modyfikujące (Ctrl, Shift, Alt) bezpośrednio"
+#: src/snes9x.ui:5542
+msgid "Use _modifier keys (Ctrl, Shift, Alt) directly"
+msgstr "Używaj klawisze modyfikujące (Ctrl, Shift, Alt) bezpośrednio"
 
-#: src/snes9x.ui:5572
+#: src/snes9x.ui:5546
 msgid "Allow using modifier keys as independent keys instead of modifiers"
 msgstr "Umożliwia używanie klawiszy modyfikujących jako niezależne klawisze"
 
-#: src/snes9x.ui:5606
+#: src/snes9x.ui:5581
 msgid "Up"
 msgstr "↑"
 
-#: src/snes9x.ui:5618
+#: src/snes9x.ui:5593
 msgid "Down"
 msgstr "↓"
 
-#: src/snes9x.ui:5632
+#: src/snes9x.ui:5607
 msgid "Left"
 msgstr "←"
 
-#: src/snes9x.ui:5646
+#: src/snes9x.ui:5621
 msgid "Right"
 msgstr "→"
 
-#: src/snes9x.ui:5660
+#: src/snes9x.ui:5635
 msgid "Start"
 msgstr "_Start"
 
-#: src/snes9x.ui:5674
+#: src/snes9x.ui:5649
 msgid "Select"
 msgstr "Sele_ct"
 
-#: src/snes9x.ui:5815 src/snes9x.ui:6045 src/snes9x.ui:6257
+#: src/snes9x.ui:5790 src/snes9x.ui:6020 src/snes9x.ui:6232
 msgid "A"
 msgstr "_A"
 
-#: src/snes9x.ui:5827 src/snes9x.ui:6057 src/snes9x.ui:6269
+#: src/snes9x.ui:5802 src/snes9x.ui:6032 src/snes9x.ui:6244
 msgid "B"
 msgstr "_B"
 
-#: src/snes9x.ui:5841 src/snes9x.ui:6071 src/snes9x.ui:6283
+#: src/snes9x.ui:5816 src/snes9x.ui:6046 src/snes9x.ui:6258
 msgid "X"
 msgstr "_X"
 
-#: src/snes9x.ui:5855 src/snes9x.ui:6085 src/snes9x.ui:6297
+#: src/snes9x.ui:5830 src/snes9x.ui:6060 src/snes9x.ui:6272
 msgid "Y"
 msgstr "_Y"
 
-#: src/snes9x.ui:5869 src/snes9x.ui:6099 src/snes9x.ui:6311
+#: src/snes9x.ui:5844 src/snes9x.ui:6074 src/snes9x.ui:6286
 msgid "L"
 msgstr "_L"
 
-#: src/snes9x.ui:5883 src/snes9x.ui:6113 src/snes9x.ui:6325
+#: src/snes9x.ui:5858 src/snes9x.ui:6088 src/snes9x.ui:6300
 msgid "R"
 msgstr "_R"
 
-#: src/snes9x.ui:6017
+#: src/snes9x.ui:5992
 msgid "Buttons"
 msgstr "Przyciski"
 
-#: src/snes9x.ui:6458
+#: src/snes9x.ui:6433
 msgid "<b>Sticky</b>"
 msgstr "<b>Kleiste</b>"
 
-#: src/snes9x.ui:6474
+#: src/snes9x.ui:6449
 msgid "<b>Turbo</b>"
 msgstr "<b>Turbo</b>"
 
-#: src/snes9x.ui:6493
+#: src/snes9x.ui:6468
 msgid "Turbo / Sticky Buttons"
-msgstr "Turbo i kleiste przyciski"
+msgstr "Turbo i przyciski kleiste"
 
-#: src/snes9x.ui:6530
+#: src/snes9x.ui:6505
 msgid "Set new axis bindings at:"
 msgstr "_Rejestruj naciśnięcie przycisku przy odchyleniu osi o "
 
-#: src/snes9x.ui:6542
+#: src/snes9x.ui:6517
 msgid ""
 "Changes the amount a joystick should be tilted to register a button press"
 msgstr ""
 "Zmienia próg odchylenia joysticka od którego rejestrowane jest naciśnięcie "
 "przycisku."
 
-# TODO: convert to plurals
-#: src/snes9x.ui:6561
+#: src/snes9x.ui:6536
 msgid "percent"
 msgstr " procent"
 
-#: src/snes9x.ui:6578
+#: src/snes9x.ui:6553
 msgid "<b>Joystick Axis Threshold</b>"
 msgstr "<b>Próg osi joysticka</b>"
 
-#: src/snes9x.ui:6615
+#: src/snes9x.ui:6590
 msgid "Center all axes on all joysticks and press Calibrate."
 msgstr "Wycentruj wszystkie osie wszystkich joysticków i naciśnij „Kalibruj…”"
 
-#: src/snes9x.ui:6630
+#: src/snes9x.ui:6605
 msgid "Cali_brate"
 msgstr "_Kalibruj…"
 
-#: src/snes9x.ui:6663
+#: src/snes9x.ui:6638
 msgid "<b>Calibration</b>"
 msgstr "<b>Kalibracja</b>"
 
-#: src/snes9x.ui:6684
+#: src/snes9x.ui:6659
 msgid "Joystick Options"
 msgstr "Opcje joysticka"
 
-#: src/snes9x.ui:6702 src/snes9x.ui:9054
+#: src/snes9x.ui:6677 src/snes9x.ui:9029
 msgid ""
 "<small>Click an entry and then press the desired keys or joystick button\n"
-"<i>Escape</i>: Move to next<i>  Shift-Escape</i>: Clear selected</small>"
+"<tt>Escape</tt>: Move to next  <tt>Shift+Escape</tt>: Clear selected</small>"
 msgstr ""
 "<small>Kliknij na pole, a potem naciśnij pożądane klawisze lub przycisk "
-"joysticka\n<tt>Esc</tt>: Przejdź do następnego  <tt>Shift+Esc</tt>: Wyczyść "
-"pole</small>"
+"joysticka\n"
+"<tt>Esc</tt>: Przejdź do następnego  <tt>Shift+Esc</tt>: Wyczyść pole</small>"
 
-#: src/snes9x.ui:6740
+#: src/snes9x.ui:6715
 msgid "Joypads"
 msgstr "_Kontrolery"
 
-#: src/snes9x.ui:6767
+#: src/snes9x.ui:6742
 msgid "<b>Snes9x Emulator Shortcut Keys</b>"
 msgstr "<b>Skróty klawiszowe emulatora Snes9x</b>"
 
-#: src/snes9x.ui:6818
+#: src/snes9x.ui:6793
 msgid "Soft reset"
 msgstr "Uruchom ROM ponownie"
 
-#: src/snes9x.ui:6832
+#: src/snes9x.ui:6807
 msgid "Hardware reset"
 msgstr "Uruchom SNES ponownie"
 
-#: src/snes9x.ui:6846
+#: src/snes9x.ui:6821
 msgid "Increase frame time"
 msgstr "Wydłuż czas klatki"
 
-#: src/snes9x.ui:6860
+#: src/snes9x.ui:6835
 msgid "Decrease frame time"
 msgstr "Skróć czas klatki"
 
-#: src/snes9x.ui:6874
+#: src/snes9x.ui:6849
 msgid "Increase frame rate"
 msgstr "Zwiększ częstotliwość klatek"
 
-#: src/snes9x.ui:6888
+#: src/snes9x.ui:6863
 msgid "Decrease frame rate"
 msgstr "Zmniejsz częstotliwość klatek"
 
-#: src/snes9x.ui:6902
+#: src/snes9x.ui:6877
 msgid "Pause"
 msgstr "Przerwij"
 
-#: src/snes9x.ui:6916
+#: src/snes9x.ui:6891
 msgid "Toggle turbo"
 msgstr "Przełącz turbo"
 
-#: src/snes9x.ui:6930
+#: src/snes9x.ui:6905
 msgid "Enable turbo"
 msgstr "Włącz turbo"
 
-#: src/snes9x.ui:6945
+#: src/snes9x.ui:6920
 msgid "Open ROM"
 msgstr "Otwórz ROM"
 
-#: src/snes9x.ui:7204
+#: src/snes9x.ui:7179
 msgid "Toggle BG layer 0"
 msgstr "Przełącz warstwę 0 tła"
 
-#: src/snes9x.ui:7216
+#: src/snes9x.ui:7191
 msgid "Toggle BG layer 1"
 msgstr "Przełącz warstwę 1 tła"
 
-#: src/snes9x.ui:7230
+#: src/snes9x.ui:7205
 msgid "Toggle BG layer 2"
 msgstr "Przełącz warstwę 2 tła"
 
-#: src/snes9x.ui:7244
+#: src/snes9x.ui:7219
 msgid "Toggle BG layer 3"
 msgstr "Przełącz warstwę 3 tła"
 
-#: src/snes9x.ui:7258
+#: src/snes9x.ui:7233
 msgid "Toggle sprites"
 msgstr "Przełącz sprity"
 
-#: src/snes9x.ui:7272
+#: src/snes9x.ui:7247
 msgid "Toggle forced backdrop color"
 msgstr "Przełącz wymuszony kolor tła"
 
-#: src/snes9x.ui:7286
+#: src/snes9x.ui:7261
 msgid "Screenshot"
 msgstr "Zrzut ekranu"
 
-#: src/snes9x.ui:7300
+#: src/snes9x.ui:7275
 msgid "Toggle fullscreen"
 msgstr "Przełącz pełny ekran"
 
-#: src/snes9x.ui:7464
+#: src/snes9x.ui:7439
 msgid "Graphics"
 msgstr "Grafika"
 
-#: src/snes9x.ui:7501
+#: src/snes9x.ui:7476
 msgid "Save current slot"
 msgstr "Zapisz do bieżącego miejsca"
 
-#: src/snes9x.ui:7534
+#: src/snes9x.ui:7509
 msgid "Load current slot"
 msgstr "Ładuj z bieżącego miejsca"
 
-#: src/snes9x.ui:7567
+#: src/snes9x.ui:7542
 msgid "Increment and save"
 msgstr "Wybierz następne miejsce i zapisz"
 
-#: src/snes9x.ui:7600
+#: src/snes9x.ui:7575
 msgid "Decrement and load"
 msgstr "Wybierz poprzednie miejsce i ładuj"
 
-#: src/snes9x.ui:7633
+#: src/snes9x.ui:7608
 msgid "Increment slot"
 msgstr "Wybierz następne miejsce"
 
-#: src/snes9x.ui:7666
+#: src/snes9x.ui:7641
 msgid "Decrement slot"
 msgstr "Wybierz poprzednie miejsce"
 
-#: src/snes9x.ui:7710
+#: src/snes9x.ui:7685
 msgid "<b>Quick save state</b>"
 msgstr "<b>Ekspresowe zapisywanie stanu</b>"
 
-#: src/snes9x.ui:7725
+#: src/snes9x.ui:7700
 msgid "<b>Quick load state</b>"
 msgstr "<b>Ekspresowe ładowanie stanu</b>"
 
-#: src/snes9x.ui:7740 src/snes9x.ui:7880
+#: src/snes9x.ui:7715 src/snes9x.ui:7855
 msgid "Slot 0"
 msgstr "Miejsce 0"
 
-#: src/snes9x.ui:7754 src/snes9x.ui:7896
+#: src/snes9x.ui:7729 src/snes9x.ui:7871
 msgid "Slot 1"
 msgstr "Miejsce 1"
 
-#: src/snes9x.ui:7768 src/snes9x.ui:7912
+#: src/snes9x.ui:7743 src/snes9x.ui:7887
 msgid "Slot 2"
 msgstr "Miejsce 2"
 
-#: src/snes9x.ui:7782 src/snes9x.ui:7928
+#: src/snes9x.ui:7757 src/snes9x.ui:7903
 msgid "Slot 3"
 msgstr "Miejsce 3"
 
-#: src/snes9x.ui:7796 src/snes9x.ui:7944
+#: src/snes9x.ui:7771 src/snes9x.ui:7919
 msgid "Slot 4"
 msgstr "Miejsce 4"
 
-#: src/snes9x.ui:7810 src/snes9x.ui:7960
+#: src/snes9x.ui:7785 src/snes9x.ui:7935
 msgid "Slot 5"
 msgstr "Miejsce 5"
 
-#: src/snes9x.ui:7824 src/snes9x.ui:7976
+#: src/snes9x.ui:7799 src/snes9x.ui:7951
 msgid "Slot 6"
 msgstr "Miejsce 6"
 
-#: src/snes9x.ui:7838 src/snes9x.ui:7992
+#: src/snes9x.ui:7813 src/snes9x.ui:7967
 msgid "Slot 7"
 msgstr "Miejsce 7"
 
-#: src/snes9x.ui:7852 src/snes9x.ui:8008
+#: src/snes9x.ui:7827 src/snes9x.ui:7983
 msgid "Slot 8"
 msgstr "Miejsce 8"
 
-#: src/snes9x.ui:7866 src/snes9x.ui:8024
+#: src/snes9x.ui:7841 src/snes9x.ui:7999
 msgid "Slot 9"
 msgstr "Miejsce 9"
 
-#: src/snes9x.ui:8463
+#: src/snes9x.ui:8438
 msgid "Toggle sound channel 0"
 msgstr "Przełącz kanał dźwiękowy 0"
 
-#: src/snes9x.ui:8475
+#: src/snes9x.ui:8450
 msgid "Toggle sound channel 1"
 msgstr "Przełącz kanał dźwiękowy 1"
 
-#: src/snes9x.ui:8489
+#: src/snes9x.ui:8464
 msgid "Toggle sound channel 2"
 msgstr "Przełącz kanał dźwiękowy 2"
 
-#: src/snes9x.ui:8503
+#: src/snes9x.ui:8478
 msgid "Toggle sound channel 3"
 msgstr "Przełącz kanał dźwiękowy 3"
 
-#: src/snes9x.ui:8517
+#: src/snes9x.ui:8492
 msgid "Toggle sound channel 4"
 msgstr "Przełącz kanał dźwiękowy 4"
 
-#: src/snes9x.ui:8531
+#: src/snes9x.ui:8506
 msgid "Toggle sound channel 5"
 msgstr "Przełącz kanał dźwiękowy 5"
 
-#: src/snes9x.ui:8545
+#: src/snes9x.ui:8520
 msgid "Toggle sound channel 6"
 msgstr "Przełącz kanał dźwiękowy 6"
 
-#: src/snes9x.ui:8559
+#: src/snes9x.ui:8534
 msgid "Toggle sound channel 7"
 msgstr "Przełącz kanał dźwiękowy 7"
 
-#: src/snes9x.ui:8573
+#: src/snes9x.ui:8548
 msgid "Toggle all sound channels"
 msgstr "Przełącz wszystkie kanały dźwiękowe"
 
-#: src/snes9x.ui:8778
+#: src/snes9x.ui:8753
 msgid "Seek to frame"
 msgstr "Przeszukaj do klatki"
 
-#: src/snes9x.ui:8793
+#: src/snes9x.ui:8768
 msgid "Load Movie"
 msgstr "Załaduj wideo"
 
-#: src/snes9x.ui:8808
+#: src/snes9x.ui:8783
 msgid "Stop movie recording"
 msgstr "Zatrzymaj nagrywanie wideo"
 
-#: src/snes9x.ui:8823
+#: src/snes9x.ui:8798
 msgid "Begin movie recording"
 msgstr "Rozpocznij nagrywanie wideo"
 
-#: src/snes9x.ui:8838
+#: src/snes9x.ui:8813
 msgid "Save SPC"
 msgstr "Zapisz SPC"
 
-#: src/snes9x.ui:8938
+#: src/snes9x.ui:8913
 msgid "Swap controllers 1 & 2"
 msgstr "Wymień kontroler 1 z 2"
 
-#: src/snes9x.ui:8969
+#: src/snes9x.ui:8944
 msgid "Rewind"
 msgstr "Odwiń"
 
-#: src/snes9x.ui:9000
+#: src/snes9x.ui:8975
 msgid "Capture/release mouse"
 msgstr "Łap/Póść mysz"
 
-#: src/snes9x.ui:9036
+#: src/snes9x.ui:9011
 msgid "Misc"
 msgstr "Rozmaitości"
 
-#: src/snes9x.ui:9092
+#: src/snes9x.ui:9067
 msgid "Shortcuts"
 msgstr "_Skróty klawiszowe"
 
-#: src/snes9x.ui:9131
+#: src/snes9x.ui:9106
 msgid "Pause emulation when switching away from Snes9x"
 msgstr "_Przerywaj emulację po odejściu od Snes9x"
 
-#: src/snes9x.ui:9145
-msgid "Force-enable button and menu icons"
-msgstr "Wymuszaj s_ymbole na przyciskach"
+#: src/snes9x.ui:9120
+msgid "Force‑enable button and menu icons"
+msgstr "Wymuszaj s_ymbole na przyciskach i w menu"
 
-#: src/snes9x.ui:9166
-msgid "The ESC key should:"
+#: src/snes9x.ui:9141
+msgid "The <tt>Esc</tt> key should:"
 msgstr "Klawiszem <tt>_Esc</tt>:"
 
-#: src/snes9x.ui:9208
+#: src/snes9x.ui:9185
 msgid "Initial background:"
 msgstr "_Tło wstępne:"
 
-#: src/snes9x.ui:9249
+#: src/snes9x.ui:9226
 msgid "<b>Window Behavior</b>"
 msgstr "<b>Zachowanie okna</b>"
 
-#: src/snes9x.ui:9279
+#: src/snes9x.ui:9256
 msgid "Prevent the screensaver from activating"
 msgstr "_Blokuj aktywację wygaszacza ekranu"
 
-#: src/snes9x.ui:9299
+#: src/snes9x.ui:9276
 msgid "<b>Screensaver</b>"
 msgstr "<b>Wygaszacz ekranu</b>"
 
-#: src/snes9x.ui:9333
+#: src/snes9x.ui:9310
 msgid "UI"
 msgstr "_Interfejs użytkownika"
 
-#: src/snes9x.ui:9367
+#: src/snes9x.ui:9344
 msgid ""
-"  Snes9x - Portable Super Nintendo Entertainment System (TM) emulator.\n"
+"  Snes9x – A Portable Super Nintendo Entertainment System™ Emulator\n"
 "\n"
 "  Snes9x homepage: http://www.snes9x.com/\n"
 "  Snes9x source code: https://github.com/snes9xgit/snes9x/\n"
 "\n"
 "  Permission to use, copy, modify and/or distribute Snes9x in both binary\n"
-"  and source form, for non-commercial purposes, is hereby granted without\n"
+"  and source form, for non‑commercial purposes, is hereby granted without\n"
 "  fee, providing that this license information and copyright notice appear\n"
 "  with all copies and any derived work.\n"
 "\n"
-"  This software is provided 'as-is', without any express or implied\n"
+"  This software is provided ‘as‑is’, without any express or implied\n"
 "  warranty. In no event shall the authors be held liable for any damages\n"
-"  arising from the use of this software or it's derivatives.\n"
+"  arising from the use of this software or it’s derivatives.\n"
 "\n"
 "  Snes9x is freeware for PERSONAL USE only. Commercial users should\n"
 "  seek permission of the copyright holders first. Commercial use includes,\n"
@@ -1901,7 +1837,7 @@ msgid ""
 "  Super NES and Super Nintendo Entertainment System are trademarks of\n"
 "  Nintendo Co., Limited and its subsidiary companies."
 msgstr ""
-"  Snes9x, to wieloplatformowy emulator Super Nintendo Entertainment System™.\n"
+"  Snes9x, to wieloplatformowy emulator Super Nintendo Entertainment System™.\n"
 "\n"
 "  Witryna Snes9x: http://www.snes9x.com/\n"
 "  Kod źródłowy Snes9x: https://github.com/snes9xgit/snes9x/\n"

--- a/gtk/po/snes9x-gtk.pot
+++ b/gtk/po/snes9x-gtk.pot
@@ -8,14 +8,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-29 19:58+0200\n"
+"POT-Creation-Date: 2023-10-29 23:56+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
 #: src/gtk_binding.cpp:248
 msgid "Unknown"
@@ -91,90 +92,117 @@ msgstr ""
 msgid "Connection Error"
 msgstr ""
 
-#: src/gtk_preferences.cpp:21
+#: src/gtk_netplay_dialog.cpp:31
+msgid "frame behind"
+msgid_plural "frames behind"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/gtk_preferences.cpp:19
 msgid "Same location as current game"
 msgstr ""
 
-#: src/gtk_preferences.cpp:130
-msgid "HQ2x"
+#: src/gtk_preferences.cpp:110
+msgid "{0:Ld}×{1:Ld} @ {2:.3Lf} Hz"
 msgstr ""
 
-#: src/gtk_preferences.cpp:131
-msgid "HQ3x"
-msgstr ""
-
-#: src/gtk_preferences.cpp:132
-msgid "HQ4x"
-msgstr ""
-
-#: src/gtk_preferences.cpp:136
-msgid "2xBRZ"
-msgstr ""
-
-#: src/gtk_preferences.cpp:137
-msgid "3xBRZ"
-msgstr ""
-
-#: src/gtk_preferences.cpp:138
-msgid "4xBRZ"
+#: src/gtk_preferences.cpp:143
+msgid "OpenGL – Use 3D graphics hardware"
 msgstr ""
 
 #: src/gtk_preferences.cpp:145
-msgid "OpenGL - Use 3D graphics hardware"
+msgid "XVideo – Use hardware video blitter"
 msgstr ""
 
 #: src/gtk_preferences.cpp:147
-msgid "XVideo - Use hardware video blitter"
-msgstr ""
-
-#: src/gtk_preferences.cpp:149
 msgid "Vulkan"
 msgstr ""
 
-#: src/gtk_preferences.cpp:151
-msgid "None - Use software scaler"
+#: src/gtk_preferences.cpp:149
+msgid "None – Use software scaler"
 msgstr ""
 
-#: src/gtk_preferences.cpp:238
+#: src/gtk_preferences.cpp:179 src/gtk_preferences.cpp:446
+msgid "thread for filtering and scaling"
+msgid_plural "threads for filtering and scaling"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/gtk_preferences.cpp:236 src/gtk_preferences.cpp:500
+msgid "millisecond"
+msgid_plural "milliseconds"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/gtk_preferences.cpp:260 src/gtk_preferences.cpp:476
+msgid "second after change"
+msgid_plural "seconds after change"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/gtk_preferences.cpp:271
 msgid "Snes9x version: "
 msgstr ""
 
-#: src/gtk_preferences.cpp:239
+#: src/gtk_preferences.cpp:272
 msgid "GTK+ port version: "
 msgstr ""
 
-#: src/gtk_preferences.cpp:241
+#: src/gtk_preferences.cpp:274
 msgid "English localization by Brandon Wright"
 msgstr ""
 
-#: src/gtk_preferences.cpp:265
+#: src/gtk_preferences.cpp:298
 msgid "Select directory"
 msgstr ""
 
-#: src/gtk_preferences.cpp:338
+#: src/gtk_preferences.cpp:323
+msgid "{0:.4Lf} Hz"
+msgstr ""
+
+#: src/gtk_preferences.cpp:328
+msgid "{0:Ld} Hz"
+msgstr ""
+
+#: src/gtk_preferences.cpp:379
 msgid "Select Shader File"
 msgstr ""
 
-#: src/gtk_preferences.cpp:669
+#: src/gtk_preferences.cpp:720
 msgid ""
 "Changing the SRAM directory with a game loaded will replace the .srm file in "
 "the selected directory with the SRAM from the running game. If this is not "
 "what you want, click 'cancel'."
 msgstr ""
 
-#: src/gtk_preferences.cpp:674
+#: src/gtk_preferences.cpp:725
 msgid "Warning: Possible File Overwrite"
 msgstr ""
 
-#: src/gtk_preferences.cpp:929
+#: src/gtk_preferences.cpp:980
 msgid "Current joystick centers have been saved."
 msgstr ""
 
-#: src/gtk_preferences.cpp:930
+#: src/gtk_preferences.cpp:981
 msgid "Calibration Complete"
 msgstr ""
 
-#: src/gtk_s9xwindow.cpp:48 src/snes9x.ui:8430
+#: src/gtk_s9x.cpp:206
+msgid "Using rewind buffer of {0}\n"
+msgstr ""
+
+#: src/gtk_s9x.cpp:598
+msgid ""
+"GTK port options:\n"
+"-filter [option]               Use a filter to scale the image.\n"
+"                               [option] is one of: none supereagle 2xsai\n"
+"                               super2xsai hq2x hq3x hq4x 2xbrz 3xbrz 4xbrz "
+"epx ntsc\n"
+"\n"
+"-mutesound                     Disables sound output.\n"
+msgstr ""
+
+#: src/gtk_s9xwindow.cpp:48 src/snes9x.ui:8405
 msgid "Save States"
 msgstr ""
 
@@ -215,8 +243,7 @@ msgid "Load Saved State"
 msgstr ""
 
 #: src/gtk_s9xwindow.cpp:796
-#, c-format
-msgid "The current frame in the movie is <b>%d</b>."
+msgid "The current frame in the movie is <b>{0:Ld}</b>."
 msgstr ""
 
 #: src/gtk_s9xwindow.cpp:829
@@ -283,1521 +310,1457 @@ msgstr ""
 msgid "Shader Parameters"
 msgstr ""
 
-#: src/snes9x.ui:9
+#: src/snes9x.ui:10
 msgid "About Snes9x"
 msgstr ""
 
-#: src/snes9x.ui:48
-msgid "label106"
-msgstr ""
-
-#: src/snes9x.ui:278
+#: src/snes9x.ui:283
 msgid "Snes9x Cheats"
 msgstr ""
 
-#: src/snes9x.ui:396
+#: src/snes9x.ui:401
 msgid "Update Cheat"
 msgstr ""
 
-#: src/snes9x.ui:411
+#: src/snes9x.ui:416
 msgid "Disable All"
 msgstr ""
 
-#: src/snes9x.ui:427
+#: src/snes9x.ui:432
 msgid "Delete All Cheats"
 msgstr ""
 
-#: src/snes9x.ui:442
+#: src/snes9x.ui:447
 msgid "Search Cheat Database"
 msgstr ""
 
-#: src/snes9x.ui:484
+#: src/snes9x.ui:489
 msgid "Code:"
 msgstr ""
 
-#: src/snes9x.ui:521
+#: src/snes9x.ui:526
 msgid "Description:"
 msgstr ""
 
-#: src/snes9x.ui:568
+#: src/snes9x.ui:573
 msgid "Advance to Frame"
 msgstr ""
 
-#: src/snes9x.ui:637
+#: src/snes9x.ui:642
 msgid "The current frame in the movie is"
 msgstr ""
 
-#: src/snes9x.ui:658
-msgid "Fast-forward to frame"
+#: src/snes9x.ui:663
+msgid "Fast‑forward to frame"
 msgstr ""
 
-#: src/snes9x.ui:819
+#: src/snes9x.ui:806
 msgid "Black"
 msgstr ""
 
-#: src/snes9x.ui:822
+#: src/snes9x.ui:809
 msgid "Color bars"
 msgstr ""
 
-#: src/snes9x.ui:825
+#: src/snes9x.ui:812
 msgid "Pixel art patterns"
 msgstr ""
 
-#: src/snes9x.ui:828
+#: src/snes9x.ui:815
 msgid "Dithered gradient"
 msgstr ""
 
-#: src/snes9x.ui:831
+#: src/snes9x.ui:818
 msgid "Color bars and patterns"
 msgstr ""
 
-#: src/snes9x.ui:834
+#: src/snes9x.ui:821
 msgid "Starfield"
 msgstr ""
 
-#: src/snes9x.ui:837
+#: src/snes9x.ui:824
 msgid "Snow"
 msgstr ""
 
-#: src/snes9x.ui:848
-msgid "Game Genie"
-msgstr ""
-
-#: src/snes9x.ui:851
-msgid "Pro Action Replay"
-msgstr ""
-
-#: src/snes9x.ui:854
-msgid "Goldfinger"
-msgstr ""
-
-#: src/snes9x.ui:865 src/snes9x.ui:888
+#: src/snes9x.ui:852 src/snes9x.ui:875
 msgid "12.5%"
 msgstr ""
 
-#: src/snes9x.ui:868 src/snes9x.ui:891
+#: src/snes9x.ui:855 src/snes9x.ui:878
 msgid "25%"
 msgstr ""
 
-#: src/snes9x.ui:871 src/snes9x.ui:894
+#: src/snes9x.ui:858 src/snes9x.ui:881
 msgid "50%"
 msgstr ""
 
-#: src/snes9x.ui:874 src/snes9x.ui:897
+#: src/snes9x.ui:861 src/snes9x.ui:884
 msgid "100%"
 msgstr ""
 
-#: src/snes9x.ui:885
+#: src/snes9x.ui:872
 msgid "0%"
 msgstr ""
 
-#: src/snes9x.ui:908 src/snes9x.ui:1989
+#: src/snes9x.ui:895
+msgctxt "filter list"
 msgid "None"
 msgstr ""
 
-#: src/snes9x.ui:911
-msgid "SuperEagle"
-msgstr ""
-
-#: src/snes9x.ui:914
-msgid "2xSaI"
-msgstr ""
-
-#: src/snes9x.ui:917
-msgid "Super2xSaI"
-msgstr ""
-
-#: src/snes9x.ui:920
-msgid "EPX"
-msgstr ""
-
-#: src/snes9x.ui:923
-msgid "EPX Smooth"
-msgstr ""
-
-#: src/snes9x.ui:926
-msgid "Blargg's NTSC"
-msgstr ""
-
-#: src/snes9x.ui:929
-msgid "Scanlines"
-msgstr ""
-
-#: src/snes9x.ui:932
-msgid "Simple2x"
-msgstr ""
-
-#: src/snes9x.ui:935
-msgid "Simple3x"
-msgstr ""
-
-#: src/snes9x.ui:938
-msgid "Simple4x"
-msgstr ""
-
-#: src/snes9x.ui:949
+#: src/snes9x.ui:936
 msgid "8:7 Square pixels"
 msgstr ""
 
-#: src/snes9x.ui:952
+#: src/snes9x.ui:939
 msgid "8:7 Square pixels, integer multiples"
 msgstr ""
 
-#: src/snes9x.ui:955
+#: src/snes9x.ui:942
 msgid "4:3 SNES correct aspect"
 msgstr ""
 
-#: src/snes9x.ui:958
+#: src/snes9x.ui:945
 msgid "4:3 SNES correct aspect, integer multiples"
 msgstr ""
 
-#: src/snes9x.ui:961
+#: src/snes9x.ui:948
 msgid "8*8:7*7 NTSC"
 msgstr ""
 
-#: src/snes9x.ui:964
+#: src/snes9x.ui:951
 msgid "8*8:7*7 NTSC, integer multiples"
 msgstr ""
 
-#: src/snes9x.ui:981
+#: src/snes9x.ui:968
 msgid "Merge adjacent pairs"
 msgstr ""
 
-#: src/snes9x.ui:984
+#: src/snes9x.ui:971
 msgid "Output directly"
 msgstr ""
 
-#: src/snes9x.ui:987
-msgid "Scale low-resolution screens"
+#: src/snes9x.ui:974
+msgid "Scale low‑resolution screens"
 msgstr ""
 
-#: src/snes9x.ui:998 src/snes9x.ui:1036
+#: src/snes9x.ui:985 src/snes9x.ui:1023
 msgid "1"
 msgstr ""
 
-#: src/snes9x.ui:1001 src/snes9x.ui:1039
+#: src/snes9x.ui:988 src/snes9x.ui:1026
 msgid "2"
 msgstr ""
 
-#: src/snes9x.ui:1004 src/snes9x.ui:1042
+#: src/snes9x.ui:991 src/snes9x.ui:1029
 msgid "3"
 msgstr ""
 
-#: src/snes9x.ui:1007 src/snes9x.ui:1045
+#: src/snes9x.ui:994 src/snes9x.ui:1032
 msgid "4"
 msgstr ""
 
-#: src/snes9x.ui:1010 src/snes9x.ui:1048
+#: src/snes9x.ui:997 src/snes9x.ui:1035
 msgid "5"
 msgstr ""
 
-#: src/snes9x.ui:1013 src/snes9x.ui:1051
+#: src/snes9x.ui:1000 src/snes9x.ui:1038
 msgid "1+"
 msgstr ""
 
-#: src/snes9x.ui:1016 src/snes9x.ui:1054
+#: src/snes9x.ui:1003 src/snes9x.ui:1041
 msgid "2+"
 msgstr ""
 
-#: src/snes9x.ui:1019 src/snes9x.ui:1057
+#: src/snes9x.ui:1006 src/snes9x.ui:1044
 msgid "3+"
 msgstr ""
 
-#: src/snes9x.ui:1022 src/snes9x.ui:1060
+#: src/snes9x.ui:1009 src/snes9x.ui:1047
 msgid "4+"
 msgstr ""
 
-#: src/snes9x.ui:1025 src/snes9x.ui:1063
+#: src/snes9x.ui:1012 src/snes9x.ui:1050
 msgid "5+"
 msgstr ""
 
-#: src/snes9x.ui:1074
+#: src/snes9x.ui:1061
 msgid "Toggle the menu bar"
 msgstr ""
 
-#: src/snes9x.ui:1077
+#: src/snes9x.ui:1064
 msgid "Exit fullscreen mode"
 msgstr ""
 
-#: src/snes9x.ui:1080 src/snes9x.ui:6957
+#: src/snes9x.ui:1067 src/snes9x.ui:6932
 msgid "Quit Snes9x"
 msgstr ""
 
-#: src/snes9x.ui:1091
-msgid "Timer-based"
+#: src/snes9x.ui:1078
+msgid "Timer‑based"
 msgstr ""
 
-#: src/snes9x.ui:1094
-msgid "Timer-based with automatic frame-skipping"
+#: src/snes9x.ui:1081
+msgid "Timer‑based with automatic frame-skipping"
 msgstr ""
 
-#: src/snes9x.ui:1097
+#: src/snes9x.ui:1084
 msgid "Sound buffer synchronization"
 msgstr ""
 
-#: src/snes9x.ui:1100
+#: src/snes9x.ui:1087
 msgid "No throttling, use vsync to control speed"
 msgstr ""
 
-#: src/snes9x.ui:1111
-msgid "48000 hz"
+#: src/snes9x.ui:1098
+msgid "48,000 Hz"
 msgstr ""
 
-#: src/snes9x.ui:1114
-msgid "44100 hz"
+#: src/snes9x.ui:1101
+msgid "44,100 Hz"
 msgstr ""
 
-#: src/snes9x.ui:1117
-msgid "32000 hz"
+#: src/snes9x.ui:1104
+msgid "32,000 Hz"
 msgstr ""
 
-#: src/snes9x.ui:1120
-msgid "22050 hz"
+#: src/snes9x.ui:1107
+msgid "22,050 Hz"
 msgstr ""
 
-#: src/snes9x.ui:1123
-msgid "16000 hz"
+#: src/snes9x.ui:1110
+msgid "16,000 Hz"
 msgstr ""
 
-#: src/snes9x.ui:1126
-msgid "11025 hz"
+#: src/snes9x.ui:1113
+msgid "11,025 Hz"
 msgstr ""
 
-#: src/snes9x.ui:1129
-msgid "8000 hz"
+#: src/snes9x.ui:1116
+msgid "8,000 Hz"
 msgstr ""
 
-#: src/snes9x.ui:1132
-msgid "0 hz"
+#: src/snes9x.ui:1119
+msgid "0 Hz"
 msgstr ""
 
-#: src/snes9x.ui:1149
-msgid "16-bit (GL_RGB)"
+#: src/snes9x.ui:1136
+msgid "16‑bit (GL_RGB)"
 msgstr ""
 
-#: src/snes9x.ui:1152
-msgid "32-bit (GL_BGRA)"
+#: src/snes9x.ui:1139
+msgid "32‑bit (GL_BGRA)"
 msgstr ""
 
-#: src/snes9x.ui:1163
+#: src/snes9x.ui:1150
 msgid "Nearest"
 msgstr ""
 
-#: src/snes9x.ui:1166
+#: src/snes9x.ui:1153
 msgid "Linear"
 msgstr ""
 
-#: src/snes9x.ui:1169
+#: src/snes9x.ui:1156
 msgid "Gaussian (correct)"
 msgstr ""
 
-#: src/snes9x.ui:1172
+#: src/snes9x.ui:1159
 msgid "Cubic"
 msgstr ""
 
-#: src/snes9x.ui:1175
+#: src/snes9x.ui:1162
 msgid "Sinc"
 msgstr ""
 
-#: src/snes9x.ui:1188
+#: src/snes9x.ui:1175
 msgid "Snes9x"
 msgstr ""
 
-#: src/snes9x.ui:1208
+#: src/snes9x.ui:1195
 msgid "_File"
 msgstr ""
 
-#: src/snes9x.ui:1215
-msgid "_Open ROM Image..."
+#: src/snes9x.ui:1202
+msgid "_Open ROM Image…"
 msgstr ""
 
-#: src/snes9x.ui:1229
+#: src/snes9x.ui:1216
 msgid "Open Recent"
 msgstr ""
 
-#: src/snes9x.ui:1238
+#: src/snes9x.ui:1225
 msgid "Clear Recent Items"
 msgstr ""
 
-#: src/snes9x.ui:1250
-msgid "Open with _NetPlay..."
+#: src/snes9x.ui:1237
+msgid "Open with _NetPlay…"
 msgstr ""
 
-#: src/snes9x.ui:1253
+#: src/snes9x.ui:1240
 msgid "Open a ROM to use with NetPlay"
 msgstr ""
 
-#: src/snes9x.ui:1264
-msgid "Open _MultiCart..."
+#: src/snes9x.ui:1251
+msgid "Open _MultiCart…"
 msgstr ""
 
-#: src/snes9x.ui:1279
+#: src/snes9x.ui:1266
 msgid "_Load State"
 msgstr ""
 
-#: src/snes9x.ui:1289 src/snes9x.ui:1423
+#: src/snes9x.ui:1276 src/snes9x.ui:1410
 msgid "Slot _0"
 msgstr ""
 
-#: src/snes9x.ui:1298 src/snes9x.ui:1432
+#: src/snes9x.ui:1285 src/snes9x.ui:1419
 msgid "Slot _1"
 msgstr ""
 
-#: src/snes9x.ui:1307 src/snes9x.ui:1441
+#: src/snes9x.ui:1294 src/snes9x.ui:1428
 msgid "Slot _2"
 msgstr ""
 
-#: src/snes9x.ui:1316 src/snes9x.ui:1450
+#: src/snes9x.ui:1303 src/snes9x.ui:1437
 msgid "Slot _3"
 msgstr ""
 
-#: src/snes9x.ui:1325 src/snes9x.ui:1459
+#: src/snes9x.ui:1312 src/snes9x.ui:1446
 msgid "Slot _4"
 msgstr ""
 
-#: src/snes9x.ui:1334 src/snes9x.ui:1468
+#: src/snes9x.ui:1321 src/snes9x.ui:1455
 msgid "Slot _5"
 msgstr ""
 
-#: src/snes9x.ui:1343 src/snes9x.ui:1477
+#: src/snes9x.ui:1330 src/snes9x.ui:1464
 msgid "Slot _6"
 msgstr ""
 
-#: src/snes9x.ui:1352 src/snes9x.ui:1486
+#: src/snes9x.ui:1339 src/snes9x.ui:1473
 msgid "Slot _7"
 msgstr ""
 
-#: src/snes9x.ui:1361 src/snes9x.ui:1495
+#: src/snes9x.ui:1348 src/snes9x.ui:1482
 msgid "Slot _8"
 msgstr ""
 
-#: src/snes9x.ui:1370 src/snes9x.ui:1504
+#: src/snes9x.ui:1357 src/snes9x.ui:1491
 msgid "Slot _9"
 msgstr ""
 
-#: src/snes9x.ui:1385
-msgid "From _File..."
+#: src/snes9x.ui:1372
+msgid "From _File…"
 msgstr ""
 
-#: src/snes9x.ui:1400
+#: src/snes9x.ui:1387
 msgid "_Undo Load State"
 msgstr ""
 
-#: src/snes9x.ui:1413
+#: src/snes9x.ui:1400
 msgid "_Save State"
 msgstr ""
 
-#: src/snes9x.ui:1519
-msgid "To _File..."
+#: src/snes9x.ui:1506
+msgid "To _File…"
 msgstr ""
 
-#: src/snes9x.ui:1536
-msgid "Save SPC..."
+#: src/snes9x.ui:1523
+msgid "Save SPC…"
 msgstr ""
 
-#: src/snes9x.ui:1553
-msgid "Show ROM _Info..."
+#: src/snes9x.ui:1540
+msgid "Show ROM _Info…"
 msgstr ""
 
-#: src/snes9x.ui:1570
-msgid "_Quit"
+#: src/snes9x.ui:1557
+msgid "gtk-quit"
 msgstr ""
 
-#: src/snes9x.ui:1587
+#: src/snes9x.ui:1571
 msgid "_Emulation"
 msgstr ""
 
-#: src/snes9x.ui:1594
+#: src/snes9x.ui:1578
 msgid "Run / _Continue"
 msgstr ""
 
-#: src/snes9x.ui:1605
+#: src/snes9x.ui:1589
 msgid "_Pause"
 msgstr ""
 
-#: src/snes9x.ui:1623
-msgid "Load _Movie..."
+#: src/snes9x.ui:1607
+msgid "Load _Movie…"
 msgstr ""
 
-#: src/snes9x.ui:1635
-msgid "R_ecord Movie..."
+#: src/snes9x.ui:1619
+msgid "R_ecord Movie…"
 msgstr ""
 
-#: src/snes9x.ui:1647
+#: src/snes9x.ui:1631
 msgid "_Stop Recording"
 msgstr ""
 
-#: src/snes9x.ui:1659
-msgid "_Jump to Frame..."
+#: src/snes9x.ui:1643
+msgid "_Jump to Frame…"
 msgstr ""
 
-#: src/snes9x.ui:1677
+#: src/snes9x.ui:1661
 msgid "Sy_nc Clients"
 msgstr ""
 
-#: src/snes9x.ui:1694
+#: src/snes9x.ui:1678
 msgid "Reset"
 msgstr ""
 
-#: src/snes9x.ui:1706
+#: src/snes9x.ui:1690
 msgid "Soft _Reset"
 msgstr ""
 
-#: src/snes9x.ui:1723
+#: src/snes9x.ui:1707
 msgid "_View"
 msgstr ""
 
-#: src/snes9x.ui:1731
+#: src/snes9x.ui:1715
 msgid "_Toggle Menubar"
 msgstr ""
 
-#: src/snes9x.ui:1748
+#: src/snes9x.ui:1732
 msgid "_Change Size"
 msgstr ""
 
-#: src/snes9x.ui:1762
-msgid "_1x"
+#: src/snes9x.ui:1746
+msgid "_1×"
 msgstr ""
 
-#: src/snes9x.ui:1771
-msgid "_2x"
+#: src/snes9x.ui:1755
+msgid "_2×"
 msgstr ""
 
-#: src/snes9x.ui:1780
-msgid "_3x"
+#: src/snes9x.ui:1764
+msgid "_3×"
 msgstr ""
 
-#: src/snes9x.ui:1789
-msgid "_4x"
+#: src/snes9x.ui:1773
+msgid "_4×"
 msgstr ""
 
-#: src/snes9x.ui:1798
-msgid "_5x"
+#: src/snes9x.ui:1782
+msgid "_5×"
 msgstr ""
 
-#: src/snes9x.ui:1807
-msgid "_6x"
+#: src/snes9x.ui:1791
+msgid "_6×"
 msgstr ""
 
-#: src/snes9x.ui:1816
-msgid "_7x"
+#: src/snes9x.ui:1800
+msgid "_7×"
 msgstr ""
 
-#: src/snes9x.ui:1825
-msgid "_8x"
+#: src/snes9x.ui:1809
+msgid "_8×"
 msgstr ""
 
-#: src/snes9x.ui:1834
-msgid "_9x"
+#: src/snes9x.ui:1818
+msgid "_9×"
 msgstr ""
 
-#: src/snes9x.ui:1843
-msgid "1_0x"
+#: src/snes9x.ui:1827
+msgid "1_0×"
 msgstr ""
 
-#: src/snes9x.ui:1860
-msgid "_Fullscreen"
+#: src/snes9x.ui:1844
+msgid "gtk-fullscreen"
 msgstr ""
 
-#: src/snes9x.ui:1877
+#: src/snes9x.ui:1858
 msgid "_Options"
 msgstr ""
 
-#: src/snes9x.ui:1886
+#: src/snes9x.ui:1867
 msgid "Controller Ports"
 msgstr ""
 
-#: src/snes9x.ui:1895
+#: src/snes9x.ui:1876
 msgid "SNES Port 1"
 msgstr ""
 
-#: src/snes9x.ui:1905 src/snes9x.ui:1949
+#: src/snes9x.ui:1886 src/snes9x.ui:1930
 msgid "Joypad"
 msgstr ""
 
-#: src/snes9x.ui:1914 src/snes9x.ui:1958
+#: src/snes9x.ui:1895 src/snes9x.ui:1939
 msgid "Mouse"
 msgstr ""
 
-#: src/snes9x.ui:1924 src/snes9x.ui:1978
+#: src/snes9x.ui:1905 src/snes9x.ui:1959
 msgid "Superscope"
 msgstr ""
 
-#: src/snes9x.ui:1939
+#: src/snes9x.ui:1920
 msgid "SNES Port 2"
 msgstr ""
 
-#: src/snes9x.ui:1968
+#: src/snes9x.ui:1949
 msgid "Multitap"
 msgstr ""
 
-#: src/snes9x.ui:2015
-msgid "_Cheats..."
+#: src/snes9x.ui:1970
+msgctxt "SNES port 2"
+msgid "None"
 msgstr ""
 
-#: src/snes9x.ui:2029
-msgid "_Shader Parameters..."
+#: src/snes9x.ui:1996
+msgid "_Cheats…"
 msgstr ""
 
-#: src/snes9x.ui:2045
-msgid "_Preferences..."
+#: src/snes9x.ui:2010
+msgid "_Shader Parameters…"
 msgstr ""
 
-#: src/snes9x.ui:2090
+#: src/snes9x.ui:2026
+msgid "gtk-preferences"
+msgstr ""
+
+#: src/snes9x.ui:2068
 msgid "Open Multiple ROM Images (MultiCart)"
 msgstr ""
 
-#: src/snes9x.ui:2153
+#: src/snes9x.ui:2131
 msgid "Slot A:"
 msgstr ""
 
-#: src/snes9x.ui:2165
+#: src/snes9x.ui:2143
 msgid "Select an Image for Slot A"
 msgstr ""
 
-#: src/snes9x.ui:2189
+#: src/snes9x.ui:2167
 msgid "Slot B:"
 msgstr ""
 
-#: src/snes9x.ui:2201
+#: src/snes9x.ui:2179
 msgid "Select an Image for Slot B"
 msgstr ""
 
-#: src/snes9x.ui:2233
+#: src/snes9x.ui:2211
 msgid "Snes9x NetPlay"
 msgstr ""
 
-#: src/snes9x.ui:2310
+#: src/snes9x.ui:2288
 msgid ""
 "The game chosen will be loaded before connecting. This field can be blank if "
 "the server will send the ROM image"
 msgstr ""
 
-#: src/snes9x.ui:2325 src/snes9x.ui:4022 src/snes9x.ui:5137 src/snes9x.ui:5152
-#: src/snes9x.ui:5169 src/snes9x.ui:5186 src/snes9x.ui:5203
-msgid "Browse..."
+#: src/snes9x.ui:2303 src/snes9x.ui:4001 src/snes9x.ui:5116 src/snes9x.ui:5131
+#: src/snes9x.ui:5148 src/snes9x.ui:5165 src/snes9x.ui:5182
+msgid "Browse…"
 msgstr ""
 
-#: src/snes9x.ui:2347
+#: src/snes9x.ui:2325
 msgid "Clear entry"
 msgstr ""
 
-#: src/snes9x.ui:2367
+#: src/snes9x.ui:2345
 msgid "<b>ROM Image</b>"
 msgstr ""
 
-#: src/snes9x.ui:2396
+#: src/snes9x.ui:2374
 msgid "Connect to another computer"
 msgstr ""
 
-#: src/snes9x.ui:2400
+#: src/snes9x.ui:2378
 msgid "Connect to another computer that is running Snes9x NetPlay as a server"
 msgstr ""
 
-#: src/snes9x.ui:2420
+#: src/snes9x.ui:2398
 msgid "Name or IP address:"
 msgstr ""
 
-#: src/snes9x.ui:2432
+#: src/snes9x.ui:2410
 msgid "Domain name or internet protocol address of a remote computer"
 msgstr ""
 
-#: src/snes9x.ui:2448
+#: src/snes9x.ui:2426
 msgid "Port:"
 msgstr ""
 
-#: src/snes9x.ui:2460 src/snes9x.ui:2930
+#: src/snes9x.ui:2438
 msgid "Connect to specified TCP port on remote computer"
 msgstr ""
 
-#: src/snes9x.ui:2485
+#: src/snes9x.ui:2463
 msgid "Act as a server"
 msgstr ""
 
-#: src/snes9x.ui:2489
+#: src/snes9x.ui:2467
 msgid ""
 "Host a game on this computer as Player 1, requiring extra throughput to "
 "support multitple users"
 msgstr ""
 
-#: src/snes9x.ui:2509
+#: src/snes9x.ui:2487
 msgid "<b>Server</b>"
 msgstr ""
 
-#: src/snes9x.ui:2539
+#: src/snes9x.ui:2517
 msgid "Sync using reset"
 msgstr ""
 
-#: src/snes9x.ui:2543
+#: src/snes9x.ui:2521
 msgid ""
 "Reset the game when players join instead of transferring potentially "
 "unreliable freeze states"
 msgstr ""
 
-#: src/snes9x.ui:2554
+#: src/snes9x.ui:2532
 msgid "Send ROM image to clients"
 msgstr ""
 
-#: src/snes9x.ui:2558
+#: src/snes9x.ui:2536
 msgid ""
 "Send the running game image to players instead of requiring them to have "
 "their own copies"
 msgstr ""
 
-#: src/snes9x.ui:2576
+#: src/snes9x.ui:2554
 msgid "Default port:"
 msgstr ""
 
-#: src/snes9x.ui:2588
+#: src/snes9x.ui:2566
 msgid "TCP port used as a connection point for remote clients"
 msgstr ""
 
-#: src/snes9x.ui:2620
+#: src/snes9x.ui:2598
 msgid "Ask server to pause when"
 msgstr ""
 
-#: src/snes9x.ui:2650
-msgid "frames behind"
-msgstr ""
-
-#: src/snes9x.ui:2673
+#: src/snes9x.ui:2652
 msgid "<b>Settings</b>"
 msgstr ""
 
-#: src/snes9x.ui:2701
+#: src/snes9x.ui:2680
 msgid "Snes9x Preferences"
 msgstr ""
 
-#: src/snes9x.ui:2817
+#: src/snes9x.ui:2796
 msgid "Use fullscreen on ROM open"
 msgstr ""
 
-#: src/snes9x.ui:2821
+#: src/snes9x.ui:2800
 msgid "Go to fullscreen mode immediately after opening a ROM"
 msgstr ""
 
-#: src/snes9x.ui:2833
+#: src/snes9x.ui:2812
 msgid "Show local time"
 msgstr ""
 
-#: src/snes9x.ui:2848
+#: src/snes9x.ui:2827
 msgid "Show frame rate"
 msgstr ""
 
-#: src/snes9x.ui:2863
+#: src/snes9x.ui:2842
 msgid "Show pressed keys"
 msgstr ""
 
-#: src/snes9x.ui:2878
-msgid "Show fast-forward and pause indicators"
+#: src/snes9x.ui:2857
+msgid "Show fast‑forward and pause indicators"
 msgstr ""
 
-#: src/snes9x.ui:2893
+#: src/snes9x.ui:2872
 msgid "Use overscanned height"
 msgstr ""
 
-#: src/snes9x.ui:2897
+#: src/snes9x.ui:2876
 msgid "Use SNES extended height. Will probably cause letterboxing"
 msgstr ""
 
-#: src/snes9x.ui:2919
-msgid "On-screen display size:"
+#: src/snes9x.ui:2898
+msgid "On‑screen display size:"
 msgstr ""
 
-#: src/snes9x.ui:2961
+#: src/snes9x.ui:2909
+msgid "The size of on‑screen display messages in pixels"
+msgstr ""
+
+#: src/snes9x.ui:2940
 msgid "Change fullscreen resolution:"
 msgstr ""
 
-#: src/snes9x.ui:2965
+#: src/snes9x.ui:2944
 msgid "Changes the screen resolution when running Snes9x in fullscreen mode"
 msgstr ""
 
-#: src/snes9x.ui:3010
+#: src/snes9x.ui:2989
 msgid "Basic Settings"
 msgstr ""
 
-#: src/snes9x.ui:3051
+#: src/snes9x.ui:3030
 msgid "Scale image to fit window"
 msgstr ""
 
-#: src/snes9x.ui:3055
+#: src/snes9x.ui:3034
 msgid "Scales the image so no black bars are present"
 msgstr ""
 
-#: src/snes9x.ui:3075
+#: src/snes9x.ui:3054
 msgid "Aspect ratio:"
 msgstr ""
 
-#: src/snes9x.ui:3110
-msgid "Maintain aspect-ratio"
+#: src/snes9x.ui:3089
+msgid "Maintain aspect ratio"
 msgstr ""
 
-#: src/snes9x.ui:3114
+#: src/snes9x.ui:3093
 msgid "Scales the image as large as possible without distortion"
 msgstr ""
 
-#: src/snes9x.ui:3131
-msgid "Use "
-msgstr ""
-
-#: src/snes9x.ui:3135
+#: src/snes9x.ui:3108
 msgid "Allows scaling and filtering to use multiple processors"
 msgstr ""
 
-#: src/snes9x.ui:3167
-msgid "threads for filtering and scaling"
+#: src/snes9x.ui:3111
+msgid "Use"
 msgstr ""
 
-#: src/snes9x.ui:3191
-msgid "High-resolution effect:"
+#: src/snes9x.ui:3170
+msgid "High‑resolution effect:"
 msgstr ""
 
-#: src/snes9x.ui:3234
+#: src/snes9x.ui:3213
 msgid "Apply scaling filter:"
 msgstr ""
 
-#: src/snes9x.ui:3302
+#: src/snes9x.ui:3281
 msgid "Video preset:"
 msgstr ""
 
-#: src/snes9x.ui:3316
+#: src/snes9x.ui:3295
 msgid "Composite"
 msgstr ""
 
-#: src/snes9x.ui:3330
-msgid "S-Video"
+#: src/snes9x.ui:3309
+msgid "S‑Video"
 msgstr ""
 
-#: src/snes9x.ui:3344
+#: src/snes9x.ui:3323
 msgid "RGB"
 msgstr ""
 
-#: src/snes9x.ui:3358
+#: src/snes9x.ui:3337
 msgid "Monochrome"
 msgstr ""
 
-#: src/snes9x.ui:3399
+#: src/snes9x.ui:3378
 msgid "Artifacts:"
 msgstr ""
 
-#: src/snes9x.ui:3414
+#: src/snes9x.ui:3393
 msgid "Sharpness:"
 msgstr ""
 
-#: src/snes9x.ui:3429
+#: src/snes9x.ui:3408
 msgid "Brightness:"
 msgstr ""
 
-#: src/snes9x.ui:3444
+#: src/snes9x.ui:3423
 msgid "Contrast:"
 msgstr ""
 
-#: src/snes9x.ui:3459
+#: src/snes9x.ui:3438
 msgid "Saturation:"
 msgstr ""
 
-#: src/snes9x.ui:3474
+#: src/snes9x.ui:3453
 msgid "Hue:"
 msgstr ""
 
-#: src/snes9x.ui:3675
+#: src/snes9x.ui:3654
 msgid "Gamma:"
 msgstr ""
 
-#: src/snes9x.ui:3690
+#: src/snes9x.ui:3669
 msgid "Fringing:"
 msgstr ""
 
-#: src/snes9x.ui:3705
+#: src/snes9x.ui:3684
 msgid "Bleed:"
 msgstr ""
 
-#: src/snes9x.ui:3720
+#: src/snes9x.ui:3699
 msgid "Resolution:"
 msgstr ""
 
-#: src/snes9x.ui:3750
+#: src/snes9x.ui:3729
 msgid "Merge odd and even fields"
 msgstr ""
 
-#: src/snes9x.ui:3772 src/snes9x.ui:3831
+#: src/snes9x.ui:3751 src/snes9x.ui:3810
 msgid "Scanline intensity:"
 msgstr ""
 
-#: src/snes9x.ui:3876
+#: src/snes9x.ui:3855
 msgid "Scaling"
 msgstr ""
 
-#: src/snes9x.ui:3918
-msgid "Bilinear-filter output"
+#: src/snes9x.ui:3897
+msgid "Bilinear‐filter output"
+msgstr ""
+
+#: src/snes9x.ui:3912
+msgid "Use best settings for FreeSync/G‑Sync when in fullscreen"
 msgstr ""
 
 #: src/snes9x.ui:3933
-msgid "Use best settings for FreeSync/G-Sync when fullscreen"
-msgstr ""
-
-#: src/snes9x.ui:3954
 msgid "Sync to vertical blank"
 msgstr ""
 
-#: src/snes9x.ui:3958
+#: src/snes9x.ui:3937
 msgid "Sync the image to the vertical retrace to stop tearing"
 msgstr ""
 
-#: src/snes9x.ui:3970
+#: src/snes9x.ui:3949
 msgid "Reduce input lag"
 msgstr ""
 
-#: src/snes9x.ui:3974
+#: src/snes9x.ui:3953
 msgid ""
 "Sync the program with the video output after every displayed frame to reduce "
 "input latency"
 msgstr ""
 
-#: src/snes9x.ui:3990
+#: src/snes9x.ui:3969
 msgid "Shader:"
 msgstr ""
 
-#: src/snes9x.ui:4054
-msgid "Force an inverted byte-ordering"
+#: src/snes9x.ui:4033
+msgid "Force an inverted byte‑ordering"
 msgstr ""
 
-#: src/snes9x.ui:4058
+#: src/snes9x.ui:4037
 msgid ""
-"Forces a swapped byte-ordering for cases where the system's endian is used "
+"Forces a swapped byte‑ordering for cases where the system’s endian is used "
 "instead of the video card"
 msgstr ""
 
-#: src/snes9x.ui:4082
+#: src/snes9x.ui:4061
 msgid "Hardware Acceleration"
 msgstr ""
 
-#: src/snes9x.ui:4111
+#: src/snes9x.ui:4090
 msgid "Display"
 msgstr ""
 
-#: src/snes9x.ui:4164
+#: src/snes9x.ui:4143
 msgid "Sound driver:"
 msgstr ""
 
-#: src/snes9x.ui:4199
+#: src/snes9x.ui:4178
 msgid "Automatically adjust input rate to display"
 msgstr ""
 
-#: src/snes9x.ui:4203
-msgid "Sets the correct input rate based on the display's refresh rate"
+#: src/snes9x.ui:4182
+msgid "Sets the correct input rate based on the display’s refresh rate"
 msgstr ""
 
-#: src/snes9x.ui:4215
+#: src/snes9x.ui:4194
 msgid "Dynamic rate control"
 msgstr ""
 
-#: src/snes9x.ui:4219
+#: src/snes9x.ui:4198
 msgid "Smooth out slight hiccups in sound input rate"
 msgstr ""
 
-#: src/snes9x.ui:4230
+#: src/snes9x.ui:4209
 msgid "Mute sound output"
 msgstr ""
 
-#: src/snes9x.ui:4234
+#: src/snes9x.ui:4213
 msgid "Disables output of sound"
 msgstr ""
 
-#: src/snes9x.ui:4246
+#: src/snes9x.ui:4225
 msgid "Mute sound when using turbo or rewind"
 msgstr ""
 
-#: src/snes9x.ui:4250
+#: src/snes9x.ui:4229
 msgid "Disables output of sound when using turbo or rewind"
 msgstr ""
 
-#: src/snes9x.ui:4273
+#: src/snes9x.ui:4252
 msgid "Playback rate:"
 msgstr ""
 
-#: src/snes9x.ui:4308
-msgid "milliseconds"
-msgstr ""
-
-#: src/snes9x.ui:4331
+#: src/snes9x.ui:4310
 msgid "Buffer size:"
 msgstr ""
 
-#: src/snes9x.ui:4345
+#: src/snes9x.ui:4324
 msgid "Dynamic rate limit:"
 msgstr ""
 
-#: src/snes9x.ui:4390
+#: src/snes9x.ui:4369
 msgid "Input rate:"
 msgstr ""
 
-#: src/snes9x.ui:4403
+#: src/snes9x.ui:4382
 msgid ""
 "Adjust to produce more or less data. Decrease the rate if experiencing "
-"crackling. Increase the rate if experiencing frame-rate stuttering. Best used "
-"with the \"Synchronize with sound\" option"
+"crackling. Increase the rate if experiencing frame rate stuttering. Best "
+"used with the “Sound buffer synchronization” option."
 msgstr ""
 
-#: src/snes9x.ui:4452
+#: src/snes9x.ui:4432
 msgid "Video rate:"
 msgstr ""
 
-#: src/snes9x.ui:4465
-msgid "label"
-msgstr ""
-
-#: src/snes9x.ui:4490
+#: src/snes9x.ui:4469
 msgid "<b>Sound Settings</b>"
 msgstr ""
 
-#: src/snes9x.ui:4524 src/snes9x.ui:8755
+#: src/snes9x.ui:4503 src/snes9x.ui:8730
 msgid "Sound"
 msgstr ""
 
-#: src/snes9x.ui:4582
+#: src/snes9x.ui:4561
 msgid "Throttling method:"
 msgstr ""
 
-#: src/snes9x.ui:4624
+#: src/snes9x.ui:4603
 msgid "<b>Speed Control</b>"
 msgstr ""
 
-#: src/snes9x.ui:4662
+#: src/snes9x.ui:4641
 msgid "Rewind buffer size (MB):"
 msgstr ""
 
-#: src/snes9x.ui:4704
+#: src/snes9x.ui:4683
 msgid "Number of frames between rewind snapshots:"
 msgstr ""
 
-#: src/snes9x.ui:4745
+#: src/snes9x.ui:4724
 msgid "<b>Rewind Settings</b>"
 msgstr ""
 
-#: src/snes9x.ui:4776
+#: src/snes9x.ui:4755
 msgid "Allow invalid VRAM access"
 msgstr ""
 
-#: src/snes9x.ui:4780
+#: src/snes9x.ui:4759
 msgid ""
 "Allows ROM hacks to write to screen at the wrong time. Only use if you know "
 "your ROM hack expects this"
 msgstr ""
 
-#: src/snes9x.ui:4790
+#: src/snes9x.ui:4769
 msgid "Allow opposing dpad directions"
 msgstr ""
 
-#: src/snes9x.ui:4794
+#: src/snes9x.ui:4773
 msgid "Let left and right or up and down be pressed at the same time"
 msgstr ""
 
-#: src/snes9x.ui:4805
+#: src/snes9x.ui:4784
 msgid "Overclock CPU"
 msgstr ""
 
-#: src/snes9x.ui:4809
+#: src/snes9x.ui:4788
 msgid "Reduces slowdown, but has potential to break games"
 msgstr ""
 
-#: src/snes9x.ui:4820
+#: src/snes9x.ui:4799
 msgid "Remove sprite limit"
 msgstr ""
 
-#: src/snes9x.ui:4824
+#: src/snes9x.ui:4803
 msgid "Reduces flicker, but may cause graphical artifacts"
 msgstr ""
 
-#: src/snes9x.ui:4835
+#: src/snes9x.ui:4814
 msgid "Redirect echo buffer overflow"
 msgstr ""
 
-#: src/snes9x.ui:4839
+#: src/snes9x.ui:4818
 msgid "Allows old addmusic hacks to work, but will likely hurt other games"
 msgstr ""
 
-#: src/snes9x.ui:4857
+#: src/snes9x.ui:4836
 msgid "SuperFX clock speed %:"
 msgstr ""
 
-#: src/snes9x.ui:4896
+#: src/snes9x.ui:4875
 msgid "Gaussian is the correct behavior for SNES hardware"
 msgstr ""
 
-#: src/snes9x.ui:4903
+#: src/snes9x.ui:4882
 msgid "Sound filter:"
 msgstr ""
 
-#: src/snes9x.ui:4940
+#: src/snes9x.ui:4919
 msgid "<b>Hacks</b>"
 msgstr ""
 
-#: src/snes9x.ui:4982 src/snes9x.ui:7172
+#: src/snes9x.ui:4961 src/snes9x.ui:7147
 msgid "Emulation"
 msgstr ""
 
-#: src/snes9x.ui:5223
+#: src/snes9x.ui:5202
 msgid "SRAM:"
 msgstr ""
 
-#: src/snes9x.ui:5235
+#: src/snes9x.ui:5214
 msgid "Save states:"
 msgstr ""
 
-#: src/snes9x.ui:5249
+#: src/snes9x.ui:5228
 msgid "Cheats:"
 msgstr ""
 
-#: src/snes9x.ui:5263
+#: src/snes9x.ui:5242
 msgid "Patches:"
 msgstr ""
 
-#: src/snes9x.ui:5277
+#: src/snes9x.ui:5256
 msgid "Exports:"
 msgstr ""
 
-#: src/snes9x.ui:5301
+#: src/snes9x.ui:5280
 msgid "<b>Game Data Locations</b>"
 msgstr ""
 
-#: src/snes9x.ui:5334
+#: src/snes9x.ui:5313
 msgid "Save SRAM:"
 msgstr ""
 
-#: src/snes9x.ui:5346
+#: src/snes9x.ui:5325
 msgid ""
-"Automatically save the game's SRAM at this interval. Setting this to 0 will "
+"Automatically save the game’s SRAM at this interval. Setting this to 0 will "
 "only save when quitting or changing ROMs"
 msgstr ""
 
-#: src/snes9x.ui:5365
-msgid "seconds after change"
-msgstr ""
-
-#: src/snes9x.ui:5381
+#: src/snes9x.ui:5355
 msgid "<b>Automatic Saving</b>"
 msgstr ""
 
-#: src/snes9x.ui:5418
+#: src/snes9x.ui:5392
 msgid "Files"
 msgstr ""
 
-#: src/snes9x.ui:5449
+#: src/snes9x.ui:5423
 msgid "<b>Joypad:</b>"
 msgstr ""
 
-#: src/snes9x.ui:5490
+#: src/snes9x.ui:5464
 msgid "_Reset"
 msgstr ""
 
-#: src/snes9x.ui:5518
+#: src/snes9x.ui:5492
 msgid "Swap with:"
 msgstr ""
 
-#: src/snes9x.ui:5546
+#: src/snes9x.ui:5520
 msgid "_Swap"
 msgstr ""
 
-#: src/snes9x.ui:5568
-msgid "Use modifier keys (CTRL, SHIFT, ALT) directly"
+#: src/snes9x.ui:5542
+msgid "Use _modifier keys (Ctrl, Shift, Alt) directly"
 msgstr ""
 
-#: src/snes9x.ui:5572
+#: src/snes9x.ui:5546
 msgid "Allow using modifier keys as independent keys instead of modifiers"
 msgstr ""
 
-#: src/snes9x.ui:5606
+#: src/snes9x.ui:5581
 msgid "Up"
 msgstr ""
 
-#: src/snes9x.ui:5618
+#: src/snes9x.ui:5593
 msgid "Down"
 msgstr ""
 
-#: src/snes9x.ui:5632
+#: src/snes9x.ui:5607
 msgid "Left"
 msgstr ""
 
-#: src/snes9x.ui:5646
+#: src/snes9x.ui:5621
 msgid "Right"
 msgstr ""
 
-#: src/snes9x.ui:5660
+#: src/snes9x.ui:5635
 msgid "Start"
 msgstr ""
 
-#: src/snes9x.ui:5674
+#: src/snes9x.ui:5649
 msgid "Select"
 msgstr ""
 
-#: src/snes9x.ui:5815 src/snes9x.ui:6045 src/snes9x.ui:6257
+#: src/snes9x.ui:5790 src/snes9x.ui:6020 src/snes9x.ui:6232
 msgid "A"
 msgstr ""
 
-#: src/snes9x.ui:5827 src/snes9x.ui:6057 src/snes9x.ui:6269
+#: src/snes9x.ui:5802 src/snes9x.ui:6032 src/snes9x.ui:6244
 msgid "B"
 msgstr ""
 
-#: src/snes9x.ui:5841 src/snes9x.ui:6071 src/snes9x.ui:6283
+#: src/snes9x.ui:5816 src/snes9x.ui:6046 src/snes9x.ui:6258
 msgid "X"
 msgstr ""
 
-#: src/snes9x.ui:5855 src/snes9x.ui:6085 src/snes9x.ui:6297
+#: src/snes9x.ui:5830 src/snes9x.ui:6060 src/snes9x.ui:6272
 msgid "Y"
 msgstr ""
 
-#: src/snes9x.ui:5869 src/snes9x.ui:6099 src/snes9x.ui:6311
+#: src/snes9x.ui:5844 src/snes9x.ui:6074 src/snes9x.ui:6286
 msgid "L"
 msgstr ""
 
-#: src/snes9x.ui:5883 src/snes9x.ui:6113 src/snes9x.ui:6325
+#: src/snes9x.ui:5858 src/snes9x.ui:6088 src/snes9x.ui:6300
 msgid "R"
 msgstr ""
 
-#: src/snes9x.ui:6017
+#: src/snes9x.ui:5992
 msgid "Buttons"
 msgstr ""
 
-#: src/snes9x.ui:6458
+#: src/snes9x.ui:6433
 msgid "<b>Sticky</b>"
 msgstr ""
 
-#: src/snes9x.ui:6474
+#: src/snes9x.ui:6449
 msgid "<b>Turbo</b>"
 msgstr ""
 
-#: src/snes9x.ui:6493
+#: src/snes9x.ui:6468
 msgid "Turbo / Sticky Buttons"
 msgstr ""
 
-#: src/snes9x.ui:6530
+#: src/snes9x.ui:6505
 msgid "Set new axis bindings at:"
 msgstr ""
 
-#: src/snes9x.ui:6542
+#: src/snes9x.ui:6517
 msgid ""
 "Changes the amount a joystick should be tilted to register a button press"
 msgstr ""
 
-#: src/snes9x.ui:6561
+#: src/snes9x.ui:6536
 msgid "percent"
 msgstr ""
 
-#: src/snes9x.ui:6578
+#: src/snes9x.ui:6553
 msgid "<b>Joystick Axis Threshold</b>"
 msgstr ""
 
-#: src/snes9x.ui:6615
+#: src/snes9x.ui:6590
 msgid "Center all axes on all joysticks and press Calibrate."
 msgstr ""
 
-#: src/snes9x.ui:6630
+#: src/snes9x.ui:6605
 msgid "Cali_brate"
 msgstr ""
 
-#: src/snes9x.ui:6663
+#: src/snes9x.ui:6638
 msgid "<b>Calibration</b>"
 msgstr ""
 
-#: src/snes9x.ui:6684
+#: src/snes9x.ui:6659
 msgid "Joystick Options"
 msgstr ""
 
-#: src/snes9x.ui:6702 src/snes9x.ui:9054
+#: src/snes9x.ui:6677 src/snes9x.ui:9029
 msgid ""
 "<small>Click an entry and then press the desired keys or joystick button\n"
-"<i>Escape</i>: Move to next<i>  Shift-Escape</i>: Clear selected</small>"
+"<tt>Escape</tt>: Move to next  <tt>Shift+Escape</tt>: Clear selected</small>"
 msgstr ""
 
-#: src/snes9x.ui:6740
+#: src/snes9x.ui:6715
 msgid "Joypads"
 msgstr ""
 
-#: src/snes9x.ui:6767
+#: src/snes9x.ui:6742
 msgid "<b>Snes9x Emulator Shortcut Keys</b>"
 msgstr ""
 
-#: src/snes9x.ui:6818
+#: src/snes9x.ui:6793
 msgid "Soft reset"
 msgstr ""
 
-#: src/snes9x.ui:6832
+#: src/snes9x.ui:6807
 msgid "Hardware reset"
 msgstr ""
 
-#: src/snes9x.ui:6846
+#: src/snes9x.ui:6821
 msgid "Increase frame time"
 msgstr ""
 
-#: src/snes9x.ui:6860
+#: src/snes9x.ui:6835
 msgid "Decrease frame time"
 msgstr ""
 
-#: src/snes9x.ui:6874
+#: src/snes9x.ui:6849
 msgid "Increase frame rate"
 msgstr ""
 
-#: src/snes9x.ui:6888
+#: src/snes9x.ui:6863
 msgid "Decrease frame rate"
 msgstr ""
 
-#: src/snes9x.ui:6902
+#: src/snes9x.ui:6877
 msgid "Pause"
 msgstr ""
 
-#: src/snes9x.ui:6916
+#: src/snes9x.ui:6891
 msgid "Toggle turbo"
 msgstr ""
 
-#: src/snes9x.ui:6930
+#: src/snes9x.ui:6905
 msgid "Enable turbo"
 msgstr ""
 
-#: src/snes9x.ui:6945
+#: src/snes9x.ui:6920
 msgid "Open ROM"
 msgstr ""
 
-#: src/snes9x.ui:7204
+#: src/snes9x.ui:7179
 msgid "Toggle BG layer 0"
 msgstr ""
 
-#: src/snes9x.ui:7216
+#: src/snes9x.ui:7191
 msgid "Toggle BG layer 1"
 msgstr ""
 
-#: src/snes9x.ui:7230
+#: src/snes9x.ui:7205
 msgid "Toggle BG layer 2"
 msgstr ""
 
-#: src/snes9x.ui:7244
+#: src/snes9x.ui:7219
 msgid "Toggle BG layer 3"
 msgstr ""
 
-#: src/snes9x.ui:7258
+#: src/snes9x.ui:7233
 msgid "Toggle sprites"
 msgstr ""
 
-#: src/snes9x.ui:7272
+#: src/snes9x.ui:7247
 msgid "Toggle forced backdrop color"
 msgstr ""
 
-#: src/snes9x.ui:7286
+#: src/snes9x.ui:7261
 msgid "Screenshot"
 msgstr ""
 
-#: src/snes9x.ui:7300
+#: src/snes9x.ui:7275
 msgid "Toggle fullscreen"
 msgstr ""
 
-#: src/snes9x.ui:7464
+#: src/snes9x.ui:7439
 msgid "Graphics"
 msgstr ""
 
-#: src/snes9x.ui:7501
+#: src/snes9x.ui:7476
 msgid "Save current slot"
 msgstr ""
 
-#: src/snes9x.ui:7534
+#: src/snes9x.ui:7509
 msgid "Load current slot"
 msgstr ""
 
-#: src/snes9x.ui:7567
+#: src/snes9x.ui:7542
 msgid "Increment and save"
 msgstr ""
 
-#: src/snes9x.ui:7600
+#: src/snes9x.ui:7575
 msgid "Decrement and load"
 msgstr ""
 
-#: src/snes9x.ui:7633
+#: src/snes9x.ui:7608
 msgid "Increment slot"
 msgstr ""
 
-#: src/snes9x.ui:7666
+#: src/snes9x.ui:7641
 msgid "Decrement slot"
 msgstr ""
 
-#: src/snes9x.ui:7710
+#: src/snes9x.ui:7685
 msgid "<b>Quick save state</b>"
 msgstr ""
 
-#: src/snes9x.ui:7725
+#: src/snes9x.ui:7700
 msgid "<b>Quick load state</b>"
 msgstr ""
 
-#: src/snes9x.ui:7740 src/snes9x.ui:7880
+#: src/snes9x.ui:7715 src/snes9x.ui:7855
 msgid "Slot 0"
 msgstr ""
 
-#: src/snes9x.ui:7754 src/snes9x.ui:7896
+#: src/snes9x.ui:7729 src/snes9x.ui:7871
 msgid "Slot 1"
 msgstr ""
 
-#: src/snes9x.ui:7768 src/snes9x.ui:7912
+#: src/snes9x.ui:7743 src/snes9x.ui:7887
 msgid "Slot 2"
 msgstr ""
 
-#: src/snes9x.ui:7782 src/snes9x.ui:7928
+#: src/snes9x.ui:7757 src/snes9x.ui:7903
 msgid "Slot 3"
 msgstr ""
 
-#: src/snes9x.ui:7796 src/snes9x.ui:7944
+#: src/snes9x.ui:7771 src/snes9x.ui:7919
 msgid "Slot 4"
 msgstr ""
 
-#: src/snes9x.ui:7810 src/snes9x.ui:7960
+#: src/snes9x.ui:7785 src/snes9x.ui:7935
 msgid "Slot 5"
 msgstr ""
 
-#: src/snes9x.ui:7824 src/snes9x.ui:7976
+#: src/snes9x.ui:7799 src/snes9x.ui:7951
 msgid "Slot 6"
 msgstr ""
 
-#: src/snes9x.ui:7838 src/snes9x.ui:7992
+#: src/snes9x.ui:7813 src/snes9x.ui:7967
 msgid "Slot 7"
 msgstr ""
 
-#: src/snes9x.ui:7852 src/snes9x.ui:8008
+#: src/snes9x.ui:7827 src/snes9x.ui:7983
 msgid "Slot 8"
 msgstr ""
 
-#: src/snes9x.ui:7866 src/snes9x.ui:8024
+#: src/snes9x.ui:7841 src/snes9x.ui:7999
 msgid "Slot 9"
 msgstr ""
 
-#: src/snes9x.ui:8463
+#: src/snes9x.ui:8438
 msgid "Toggle sound channel 0"
 msgstr ""
 
-#: src/snes9x.ui:8475
+#: src/snes9x.ui:8450
 msgid "Toggle sound channel 1"
 msgstr ""
 
-#: src/snes9x.ui:8489
+#: src/snes9x.ui:8464
 msgid "Toggle sound channel 2"
 msgstr ""
 
-#: src/snes9x.ui:8503
+#: src/snes9x.ui:8478
 msgid "Toggle sound channel 3"
 msgstr ""
 
-#: src/snes9x.ui:8517
+#: src/snes9x.ui:8492
 msgid "Toggle sound channel 4"
 msgstr ""
 
-#: src/snes9x.ui:8531
+#: src/snes9x.ui:8506
 msgid "Toggle sound channel 5"
 msgstr ""
 
-#: src/snes9x.ui:8545
+#: src/snes9x.ui:8520
 msgid "Toggle sound channel 6"
 msgstr ""
 
-#: src/snes9x.ui:8559
+#: src/snes9x.ui:8534
 msgid "Toggle sound channel 7"
 msgstr ""
 
-#: src/snes9x.ui:8573
+#: src/snes9x.ui:8548
 msgid "Toggle all sound channels"
 msgstr ""
 
-#: src/snes9x.ui:8778
+#: src/snes9x.ui:8753
 msgid "Seek to frame"
 msgstr ""
 
-#: src/snes9x.ui:8793
+#: src/snes9x.ui:8768
 msgid "Load Movie"
 msgstr ""
 
-#: src/snes9x.ui:8808
+#: src/snes9x.ui:8783
 msgid "Stop movie recording"
 msgstr ""
 
-#: src/snes9x.ui:8823
+#: src/snes9x.ui:8798
 msgid "Begin movie recording"
 msgstr ""
 
-#: src/snes9x.ui:8838
+#: src/snes9x.ui:8813
 msgid "Save SPC"
 msgstr ""
 
-#: src/snes9x.ui:8938
+#: src/snes9x.ui:8913
 msgid "Swap controllers 1 & 2"
 msgstr ""
 
-#: src/snes9x.ui:8969
+#: src/snes9x.ui:8944
 msgid "Rewind"
 msgstr ""
 
-#: src/snes9x.ui:9000
+#: src/snes9x.ui:8975
 msgid "Capture/release mouse"
 msgstr ""
 
-#: src/snes9x.ui:9036
+#: src/snes9x.ui:9011
 msgid "Misc"
 msgstr ""
 
-#: src/snes9x.ui:9092
+#: src/snes9x.ui:9067
 msgid "Shortcuts"
 msgstr ""
 
-#: src/snes9x.ui:9131
+#: src/snes9x.ui:9106
 msgid "Pause emulation when switching away from Snes9x"
 msgstr ""
 
-#: src/snes9x.ui:9145
-msgid "Force-enable button and menu icons"
+#: src/snes9x.ui:9120
+msgid "Force‑enable button and menu icons"
 msgstr ""
 
-#: src/snes9x.ui:9166
-msgid "The ESC key should:"
+#: src/snes9x.ui:9141
+msgid "The <tt>Esc</tt> key should:"
 msgstr ""
 
-#: src/snes9x.ui:9208
+#: src/snes9x.ui:9185
 msgid "Initial background:"
 msgstr ""
 
-#: src/snes9x.ui:9249
+#: src/snes9x.ui:9226
 msgid "<b>Window Behavior</b>"
 msgstr ""
 
-#: src/snes9x.ui:9279
+#: src/snes9x.ui:9256
 msgid "Prevent the screensaver from activating"
 msgstr ""
 
-#: src/snes9x.ui:9299
+#: src/snes9x.ui:9276
 msgid "<b>Screensaver</b>"
 msgstr ""
 
-#: src/snes9x.ui:9333
+#: src/snes9x.ui:9310
 msgid "UI"
 msgstr ""
 
-#: src/snes9x.ui:9367
+#: src/snes9x.ui:9344
 msgid ""
-"  Snes9x - Portable Super Nintendo Entertainment System (TM) emulator.\n"
+"  Snes9x – A Portable Super Nintendo Entertainment System™ Emulator\n"
 "\n"
 "  Snes9x homepage: http://www.snes9x.com/\n"
 "  Snes9x source code: https://github.com/snes9xgit/snes9x/\n"
 "\n"
 "  Permission to use, copy, modify and/or distribute Snes9x in both binary\n"
-"  and source form, for non-commercial purposes, is hereby granted without\n"
+"  and source form, for non‑commercial purposes, is hereby granted without\n"
 "  fee, providing that this license information and copyright notice appear\n"
 "  with all copies and any derived work.\n"
 "\n"
-"  This software is provided 'as-is', without any express or implied\n"
+"  This software is provided ‘as‑is’, without any express or implied\n"
 "  warranty. In no event shall the authors be held liable for any damages\n"
-"  arising from the use of this software or it's derivatives.\n"
+"  arising from the use of this software or it’s derivatives.\n"
 "\n"
 "  Snes9x is freeware for PERSONAL USE only. Commercial users should\n"
 "  seek permission of the copyright holders first. Commercial use includes,\n"
 "  but is not limited to, charging money for Snes9x or software derived from\n"
-"  Snes9x, including Snes9x or derivatives in commercial game bundles, and/or\n"
+"  Snes9x, including Snes9x or derivatives in commercial game bundles, and/"
+"or\n"
 "  using Snes9x as a promotion for your commercial product.\n"
 "\n"
 "  The copyright holders request that bug fixes and improvements to the code\n"
-"  should be forwarded to them so everyone can benefit from the modifications\n"
+"  should be forwarded to them so everyone can benefit from the "
+"modifications\n"
 "  in future versions.\n"
 "\n"
 "  Super NES and Super Nintendo Entertainment System are trademarks of\n"

--- a/gtk/src/gtk_builder_window.cpp
+++ b/gtk/src/gtk_builder_window.cpp
@@ -62,6 +62,11 @@ int GtkBuilderWindow::get_height()
     return window->get_height();
 }
 
+void GtkBuilderWindow::set_label(const char * const name, const char * const label)
+{
+    get_object<Gtk::Label>(name)->set_label(label);
+}
+
 void GtkBuilderWindow::set_button_label(const char *name, const char *label)
 {
     get_object<Gtk::Button>(name)->set_label(label);

--- a/gtk/src/gtk_builder_window.h
+++ b/gtk/src/gtk_builder_window.h
@@ -37,6 +37,7 @@ class GtkBuilderWindow
 
     void enable_widget(const char *name, bool state);
     void show_widget(const char *name, bool state);
+    void set_label(const char * const name, const char * const label);
     void set_button_label(const char *name, const char *label);
     bool get_check(const char *name);
     int get_entry_value(const char *name);

--- a/gtk/src/gtk_netplay_dialog.cpp
+++ b/gtk/src/gtk_netplay_dialog.cpp
@@ -23,6 +23,13 @@ Snes9xNetplayDialog::Snes9xNetplayDialog(Snes9xConfig *config)
         if (!filename.empty())
             get_object<Gtk::Entry>("rom_image")->set_text(filename);
     });
+    // Handle plurals on GtkLabel "frames_behind_label"
+    get_object<Gtk::SpinButton>("frames_behind")->signal_value_changed().connect([&] {
+        set_label("frames_behind_label",
+            // GLib’s g_dngettext() would have been a better fit here but
+            // xgettext does not extract g_dngettext() by default
+            ngettext("frame behind", "frames behind", get_spin("frames_behind")));
+    });
 
     this->config = config;
 }

--- a/gtk/src/gtk_preferences.h
+++ b/gtk/src/gtk_preferences.h
@@ -14,7 +14,7 @@
 void snes9x_preferences_create(Snes9xConfig *config);
 void snes9x_preferences_open(Snes9xWindow *window);
 
-class Snes9xPreferences : public GtkBuilderWindow
+class Snes9xPreferences final : public GtkBuilderWindow
 {
   public:
     Snes9xPreferences(Snes9xConfig *config);
@@ -49,6 +49,7 @@ class Snes9xPreferences : public GtkBuilderWindow
   private:
     void get_settings_from_dialog();
     void move_settings_to_dialog();
+    Glib::ustring format_sound_input_rate_value(double);
 };
 
 #endif /* __GTK_PREFERENCES_H */

--- a/gtk/src/gtk_s9x.cpp
+++ b/gtk/src/gtk_s9x.cpp
@@ -4,8 +4,9 @@
    For further information, consult the LICENSE file in the root directory.
 \*****************************************************************************/
 
-#include <stdio.h>
 #include <signal.h>
+#define G_LOG_USE_STRUCTURED
+#define G_LOG_DOMAIN GETTEXT_PACKAGE
 #include "gtk_compat.h"
 #include "gtk_config.h"
 #include "gtk_s9x.h"
@@ -52,7 +53,7 @@ int main(int argc, char *argv[])
 {
     auto app = Gtk::Application::create("com.snes9x.gtk", Gio::APPLICATION_NON_UNIQUE);
 
-    setlocale(LC_ALL, "");
+    std::locale::global(std::locale(""));
     bindtextdomain(GETTEXT_PACKAGE, SNES9XLOCALEDIR);
     bind_textdomain_codeset(GETTEXT_PACKAGE, "UTF-8");
     textdomain(GETTEXT_PACKAGE);
@@ -199,7 +200,13 @@ int S9xOpenROM(const char *rom_filename)
 
     if (state_manager.init(gui_config->rewind_buffer_size * 1024 * 1024))
     {
-        printf("Using rewind buffer of %uMB\n", gui_config->rewind_buffer_size);
+        S9xMessage(
+            S9X_INFO,
+            S9X_NO_INFO,
+            fmt::format(_("Using rewind buffer of {0}\n"),
+                Glib::format_size(
+                    gui_config->rewind_buffer_size * 1024 * 1024,
+                    Glib::FORMAT_SIZE_IEC_UNITS).c_str()).c_str());
     }
 
     S9xROMLoaded();
@@ -359,16 +366,55 @@ void S9xMessage(int type, int number, const char *message)
 {
     switch (number)
     {
-    case S9X_MOVIE_INFO:
-        S9xSetInfoString(message);
-        break;
-    case S9X_ROM_INFO:
-    {
-        S9xSetInfoString(Memory.GetMultilineROMInfo().c_str());
-        break;
-    }
-    default:
-        break;
+        case S9X_MOVIE_INFO:
+        {
+            S9xSetInfoString(message);
+            break;
+        }
+        case S9X_ROM_INFO:
+        {
+            S9xSetInfoString(Memory.GetMultilineROMInfo().c_str());
+            break;
+        }
+        default:
+        {
+            switch (type)
+            {
+                case S9X_TRACE:
+                case S9X_DEBUG:
+                {
+                    g_debug(message);
+                    break;
+                }
+                case S9X_WARNING:
+                {
+                    g_warning(message);
+                    break;
+                }
+                case S9X_INFO:
+                {
+                    g_info(message);
+                    g_message(message);
+                    break;
+                }
+                case S9X_ERROR:
+                {
+                    // GLib’s g_critical() does not terminate the process
+                    g_critical(message);
+                    break;
+                }
+                case S9X_FATAL_ERROR:
+                {
+                    // GLib’s g_error() terminates the process
+                    g_error(message);
+                    break;
+                }
+                default:
+                {
+                    g_message(message);
+                }
+            }
+        }
     }
 }
 
@@ -550,10 +596,11 @@ const char *S9xStringInput(const char *message)
 
 void S9xExtraUsage()
 {
-    printf("GTK port options:\n"
+    S9xMessage(S9X_INFO, S9X_USAGE,
+         _("GTK port options:\n"
            "-filter [option]               Use a filter to scale the image.\n"
            "                               [option] is one of: none supereagle 2xsai\n"
            "                               super2xsai hq2x hq3x hq4x 2xbrz 3xbrz 4xbrz epx ntsc\n"
            "\n"
-           "-mutesound                     Disables sound output.\n");
+           "-mutesound                     Disables sound output.\n"));
 }

--- a/gtk/src/gtk_s9x.h
+++ b/gtk/src/gtk_s9x.h
@@ -12,7 +12,7 @@
 
 #include <glib/gi18n.h>
 
-#define SNES9X_GTK_AUTHORS "(c) 2007 - 2020 Brandon Wright (bearoso@gmail.com)"
+#define SNES9X_GTK_AUTHORS "© 2007 - 2023 Brandon Wright (bearoso@gmail.com)"
 #define SNES9X_GTK_VERSION "87"
 
 extern Snes9xWindow *top_level;

--- a/gtk/src/gtk_s9xwindow.cpp
+++ b/gtk/src/gtk_s9xwindow.cpp
@@ -30,6 +30,8 @@
 #include "gtk_netplay.h"
 #include "gtk_s9xwindow.h"
 
+#include "fmt/format.h"
+
 #include "snes9x.h"
 #include "controls.h"
 #include "movie.h"
@@ -784,8 +786,6 @@ void Snes9xWindow::load_state_dialog()
 
 void Snes9xWindow::movie_seek_dialog()
 {
-    char str[1024];
-
     if (!S9xMovieActive())
         return;
 
@@ -793,11 +793,14 @@ void Snes9xWindow::movie_seek_dialog()
 
     GtkBuilderWindow seek_dialog("frame_advance_dialog");
 
-    snprintf(str, 1024, _("The current frame in the movie is <b>%d</b>."), S9xMovieGetFrameCounter());
-    seek_dialog.get_object<Gtk::Label>("current_frame_label")->set_label(str);
+    {
+        std::string str;
+        str = fmt::format(_("The current frame in the movie is <b>{0:Ld}</b>."), S9xMovieGetFrameCounter());
+        seek_dialog.get_object<Gtk::Label>("current_frame_label")->set_label(str);
 
-    snprintf(str, 1024, "%d", S9xMovieGetFrameCounter());
-    seek_dialog.set_entry_text("frame_entry", str);
+        str = fmt::format("{0:d}", S9xMovieGetFrameCounter());
+        seek_dialog.set_entry_text("frame_entry", str);
+    }
 
     auto dialog = Glib::RefPtr<Gtk::Dialog>::cast_static(seek_dialog.window);
 

--- a/gtk/src/snes9x.ui
+++ b/gtk/src/snes9x.ui
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-  <requires lib="gtk+" version="2.16"/>
+  <requires lib="gtk+" version="3.24"/>
   <!-- interface-naming-policy project-wide -->
   <object class="GtkDialog" id="about_dialog">
+  <!-- TODO: Replace GtkDialog with GtkAboutDialog -->
     <property name="width_request">560</property>
     <property name="height_request">448</property>
     <property name="can_focus">False</property>
@@ -45,7 +46,6 @@
                 <property name="yalign">0</property>
                 <property name="xpad">10</property>
                 <property name="ypad">10</property>
-                <property name="label" translatable="yes">label106</property>
                 <property name="use_markup">True</property>
                 <property name="justify">center</property>
                 <property name="wrap">True</property>
@@ -163,6 +163,11 @@
     <property name="value">100</property>
     <property name="step_increment">10</property>
     <property name="page_increment">10</property>
+  </object>
+  <object class="GtkAdjustment" id="save_sram_after_sec_adjustment">
+    <property name="upper">3600</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">60</property>
   </object>
   <object class="GtkAdjustment" id="adjustment13">
     <property name="lower">-1</property>
@@ -655,7 +660,7 @@
                     <property name="can_focus">False</property>
                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                     <property name="xalign">0</property>
-                    <property name="label" translatable="yes">Fast-forward to frame</property>
+                    <property name="label" translatable="yes">Fast‑forward to frame</property>
                   </object>
                   <packing>
                     <property name="expand">True</property>
@@ -731,28 +736,10 @@
     <property name="stock">gtk-leave-fullscreen</property>
     <property name="icon-size">1</property>
   </object>
-  <object class="GtkImage" id="image15">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="stock">gtk-fullscreen</property>
-    <property name="icon-size">1</property>
-  </object>
-  <object class="GtkImage" id="image16">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="stock">gtk-preferences</property>
-    <property name="icon-size">1</property>
-  </object>
   <object class="GtkImage" id="image17">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
     <property name="stock">gtk-zoom-in</property>
-    <property name="icon-size">1</property>
-  </object>
-  <object class="GtkImage" id="image18">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="stock">gtk-quit</property>
     <property name="icon-size">1</property>
   </object>
   <object class="GtkImage" id="image19">
@@ -845,13 +832,13 @@
     </columns>
     <data>
       <row>
-        <col id="0" translatable="yes">Game Genie</col>
+        <col id="0" translatable="no">Game Genie</col>
       </row>
       <row>
-        <col id="0" translatable="yes">Pro Action Replay</col>
+        <col id="0" translatable="no">Pro Action Replay</col>
       </row>
       <row>
-        <col id="0" translatable="yes">Goldfinger</col>
+        <col id="0" translatable="no">Goldfinger</col>
       </row>
     </data>
   </object>
@@ -905,37 +892,37 @@
     </columns>
     <data>
       <row>
-        <col id="0" translatable="yes">None</col>
+        <col id="0" translatable="yes" context="filter list">None</col>
       </row>
       <row>
-        <col id="0" translatable="yes">SuperEagle</col>
+        <col id="0" translatable="no">SuperEagle</col>
       </row>
       <row>
-        <col id="0" translatable="yes">2xSaI</col>
+        <col id="0" translatable="no">2xSaI</col>
       </row>
       <row>
-        <col id="0" translatable="yes">Super2xSaI</col>
+        <col id="0" translatable="no">Super2xSaI</col>
       </row>
       <row>
-        <col id="0" translatable="yes">EPX</col>
+        <col id="0" translatable="no">EPX</col>
       </row>
       <row>
-        <col id="0" translatable="yes">EPX Smooth</col>
+        <col id="0" translatable="no">EPX Smooth</col>
       </row>
       <row>
-        <col id="0" translatable="yes">Blargg's NTSC</col>
+        <col id="0" translatable="no">Blargg’s NTSC</col>
       </row>
       <row>
-        <col id="0" translatable="yes">Scanlines</col>
+        <col id="0" translatable="no">Scanlines</col>
       </row>
       <row>
-        <col id="0" translatable="yes">Simple2x</col>
+        <col id="0" translatable="no">Simple2x</col>
       </row>
       <row>
-        <col id="0" translatable="yes">Simple3x</col>
+        <col id="0" translatable="no">Simple3x</col>
       </row>
       <row>
-        <col id="0" translatable="yes">Simple4x</col>
+        <col id="0" translatable="no">Simple4x</col>
       </row>
     </data>
   </object>
@@ -984,7 +971,7 @@
         <col id="0" translatable="yes">Output directly</col>
       </row>
       <row>
-        <col id="0" translatable="yes">Scale low-resolution screens</col>
+        <col id="0" translatable="yes">Scale low‑resolution screens</col>
       </row>
     </data>
   </object>
@@ -1088,10 +1075,10 @@
     </columns>
     <data>
       <row>
-        <col id="0" translatable="yes">Timer-based</col>
+        <col id="0" translatable="yes">Timer‑based</col>
       </row>
       <row>
-        <col id="0" translatable="yes">Timer-based with automatic frame-skipping</col>
+        <col id="0" translatable="yes">Timer‑based with automatic frame-skipping</col>
       </row>
       <row>
         <col id="0" translatable="yes">Sound buffer synchronization</col>
@@ -1108,28 +1095,28 @@
     </columns>
     <data>
       <row>
-        <col id="0" translatable="yes">48000 hz</col>
+        <col id="0" translatable="yes">48,000 Hz</col>
       </row>
       <row>
-        <col id="0" translatable="yes">44100 hz</col>
+        <col id="0" translatable="yes">44,100 Hz</col>
       </row>
       <row>
-        <col id="0" translatable="yes">32000 hz</col>
+        <col id="0" translatable="yes">32,000 Hz</col>
       </row>
       <row>
-        <col id="0" translatable="yes">22050 hz</col>
+        <col id="0" translatable="yes">22,050 Hz</col>
       </row>
       <row>
-        <col id="0" translatable="yes">16000 hz</col>
+        <col id="0" translatable="yes">16,000 Hz</col>
       </row>
       <row>
-        <col id="0" translatable="yes">11025 hz</col>
+        <col id="0" translatable="yes">11,025 Hz</col>
       </row>
       <row>
-        <col id="0" translatable="yes">8000 hz</col>
+        <col id="0" translatable="yes">8,000 Hz</col>
       </row>
       <row>
-        <col id="0" translatable="yes">0 hz</col>
+        <col id="0" translatable="yes">0 Hz</col>
       </row>
     </data>
   </object>
@@ -1146,10 +1133,10 @@
     </columns>
     <data>
       <row>
-        <col id="0" translatable="yes">16-bit (GL_RGB)</col>
+        <col id="0" translatable="yes">16‑bit (GL_RGB)</col>
       </row>
       <row>
-        <col id="0" translatable="yes">32-bit (GL_BGRA)</col>
+        <col id="0" translatable="yes">32‑bit (GL_BGRA)</col>
       </row>
     </data>
   </object>
@@ -1212,7 +1199,7 @@
                     <property name="can_focus">False</property>
                     <child>
                       <object class="GtkImageMenuItem" id="open_rom_item">
-                        <property name="label" translatable="yes">_Open ROM Image...</property>
+                        <property name="label" translatable="yes">_Open ROM Image…</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="use_underline">True</property>
@@ -1247,7 +1234,7 @@
                     </child>
                     <child>
                       <object class="GtkImageMenuItem" id="open_netplay_item">
-                        <property name="label" translatable="yes">Open with _NetPlay...</property>
+                        <property name="label" translatable="yes">Open with _NetPlay…</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="tooltip_text" translatable="yes">Open a ROM to use with NetPlay</property>
@@ -1261,7 +1248,7 @@
                       <object class="GtkMenuItem" id="open_multicart_item">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">Open _MultiCart...</property>
+                        <property name="label" translatable="yes">Open _MultiCart…</property>
                         <property name="use_underline">True</property>
                         <signal name="activate" handler="open_multicart" swapped="no"/>
                       </object>
@@ -1382,7 +1369,7 @@
                               <object class="GtkMenuItem" id="from_file1">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="label" translatable="yes">From _File...</property>
+                                <property name="label" translatable="yes">From _File…</property>
                                 <property name="use_underline">True</property>
                                 <signal name="activate" handler="load_state_file" swapped="no"/>
                               </object>
@@ -1516,7 +1503,7 @@
                               <object class="GtkMenuItem" id="to_file1">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="label" translatable="yes">To _File...</property>
+                                <property name="label" translatable="yes">To _File…</property>
                                 <property name="use_underline">True</property>
                                 <signal name="activate" handler="save_state_file" swapped="no"/>
                               </object>
@@ -1533,7 +1520,7 @@
                     </child>
                     <child>
                       <object class="GtkImageMenuItem" id="save_spc_item">
-                        <property name="label" translatable="yes">Save SPC...</property>
+                        <property name="label" translatable="yes">Save SPC…</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="use_underline">True</property>
@@ -1550,7 +1537,7 @@
                     </child>
                     <child>
                       <object class="GtkImageMenuItem" id="rom_info_item">
-                        <property name="label" translatable="yes">Show ROM _Info...</property>
+                        <property name="label" translatable="yes">Show ROM _Info…</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="use_underline">True</property>
@@ -1567,12 +1554,9 @@
                     </child>
                     <child>
                       <object class="GtkImageMenuItem" id="exit_item">
-                        <property name="label" translatable="yes">_Quit</property>
+                        <property name="label" translatable="yes">gtk-quit</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="use_underline">True</property>
-                        <property name="image">image18</property>
-                        <property name="use_stock">False</property>
+                        <property name="use_stock">True</property>
                         <signal name="activate" handler="main_window_delete_event" swapped="no"/>
                       </object>
                     </child>
@@ -1620,7 +1604,7 @@
                     </child>
                     <child>
                       <object class="GtkImageMenuItem" id="open_movie_item">
-                        <property name="label" translatable="yes">Load _Movie...</property>
+                        <property name="label" translatable="yes">Load _Movie…</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
@@ -1632,7 +1616,7 @@
                     </child>
                     <child>
                       <object class="GtkImageMenuItem" id="record_movie_item">
-                        <property name="label" translatable="yes">R_ecord Movie...</property>
+                        <property name="label" translatable="yes">R_ecord Movie…</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
@@ -1656,7 +1640,7 @@
                     </child>
                     <child>
                       <object class="GtkImageMenuItem" id="jump_to_frame_item">
-                        <property name="label" translatable="yes">_Jump to Frame...</property>
+                        <property name="label" translatable="yes">_Jump to Frame…</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
@@ -1759,7 +1743,7 @@
                               <object class="GtkMenuItem" id="exact_pixels_1x_item">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="label" translatable="yes">_1x</property>
+                                <property name="label" translatable="yes">_1×</property>
                                 <property name="use_underline">True</property>
                                 <signal name="activate" handler="exact_1x" swapped="no"/>
                               </object>
@@ -1768,7 +1752,7 @@
                               <object class="GtkMenuItem" id="exact_pixels_2x_item">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="label" translatable="yes">_2x</property>
+                                <property name="label" translatable="yes">_2×</property>
                                 <property name="use_underline">True</property>
                                 <signal name="activate" handler="exact_2x" swapped="no"/>
                               </object>
@@ -1777,7 +1761,7 @@
                               <object class="GtkMenuItem" id="exact_pixels_3x_item">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="label" translatable="yes">_3x</property>
+                                <property name="label" translatable="yes">_3×</property>
                                 <property name="use_underline">True</property>
                                 <signal name="activate" handler="exact_3x" swapped="no"/>
                               </object>
@@ -1786,7 +1770,7 @@
                               <object class="GtkMenuItem" id="exact_pixels_4x_item">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="label" translatable="yes">_4x</property>
+                                <property name="label" translatable="yes">_4×</property>
                                 <property name="use_underline">True</property>
                                 <signal name="activate" handler="exact_4x" swapped="no"/>
                               </object>
@@ -1795,7 +1779,7 @@
                               <object class="GtkMenuItem" id="exact_pixels_5x_item">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="label" translatable="yes">_5x</property>
+                                <property name="label" translatable="yes">_5×</property>
                                 <property name="use_underline">True</property>
                                 <signal name="activate" handler="exact_5x" swapped="no"/>
                               </object>
@@ -1804,7 +1788,7 @@
                               <object class="GtkMenuItem" id="exact_pixels_6x_item">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="label" translatable="yes">_6x</property>
+                                <property name="label" translatable="yes">_6×</property>
                                 <property name="use_underline">True</property>
                                 <signal name="activate" handler="exact_6x" swapped="no"/>
                               </object>
@@ -1813,7 +1797,7 @@
                               <object class="GtkMenuItem" id="exact_pixels_7x_item">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="label" translatable="yes">_7x</property>
+                                <property name="label" translatable="yes">_7×</property>
                                 <property name="use_underline">True</property>
                                 <signal name="activate" handler="exact_7x" swapped="no"/>
                               </object>
@@ -1822,7 +1806,7 @@
                               <object class="GtkMenuItem" id="exact_pixels_8x_item">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="label" translatable="yes">_8x</property>
+                                <property name="label" translatable="yes">_8×</property>
                                 <property name="use_underline">True</property>
                                 <signal name="activate" handler="exact_8x" swapped="no"/>
                               </object>
@@ -1831,7 +1815,7 @@
                               <object class="GtkMenuItem" id="exact_pixels_9x_item">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="label" translatable="yes">_9x</property>
+                                <property name="label" translatable="yes">_9×</property>
                                 <property name="use_underline">True</property>
                                 <signal name="activate" handler="exact_9x" swapped="no"/>
                               </object>
@@ -1840,7 +1824,7 @@
                               <object class="GtkMenuItem" id="exact_pixels_10x_item">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="label" translatable="yes">1_0x</property>
+                                <property name="label" translatable="yes">1_0×</property>
                                 <property name="use_underline">True</property>
                                 <signal name="activate" handler="exact_10x" swapped="no"/>
                               </object>
@@ -1857,12 +1841,9 @@
                     </child>
                     <child>
                       <object class="GtkImageMenuItem" id="fullscreen_item">
-                        <property name="label" translatable="yes">_Fullscreen</property>
+                        <property name="label" translatable="yes">gtk-fullscreen</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="use_underline">True</property>
-                        <property name="image">image15</property>
-                        <property name="use_stock">False</property>
+                        <property name="use_stock">True</property>
                         <signal name="activate" handler="on_fullscreen_item_activate" swapped="no"/>
                       </object>
                     </child>
@@ -1986,7 +1967,7 @@
                                       <object class="GtkRadioMenuItem" id="nothingpluggedin2">
                                         <property name="visible">True</property>
                                         <property name="can_focus">False</property>
-                                        <property name="label" translatable="yes">None</property>
+                                        <property name="label" translatable="yes" context="SNES port 2">None</property>
                                         <property name="use_underline">True</property>
                                         <property name="active">True</property>
                                         <property name="group">joypad2</property>
@@ -2012,7 +1993,7 @@
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                        <property name="label" translatable="yes">_Cheats...</property>
+                        <property name="label" translatable="yes">_Cheats…</property>
                         <property name="use_underline">True</property>
                         <signal name="activate" handler="open_cheats" swapped="no"/>
                       </object>
@@ -2026,7 +2007,7 @@
                     </child>
                     <child>
                       <object class="GtkMenuItem" id="shader_parameters_item">
-                        <property name="label" translatable="yes">_Shader Parameters...</property>
+                        <property name="label" translatable="yes">_Shader Parameters…</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="use_underline">True</property>
@@ -2042,12 +2023,9 @@
                     </child>
                     <child>
                       <object class="GtkImageMenuItem" id="preferences_item">
-                        <property name="label" translatable="yes">_Preferences...</property>
+                        <property name="label" translatable="yes">gtk-preferences</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="use_underline">True</property>
-                        <property name="image">image16</property>
-                        <property name="use_stock">False</property>
+                        <property name="use_stock">True</property>
                         <signal name="activate" handler="on_preferences_item_activate" swapped="no"/>
                       </object>
                     </child>
@@ -2322,7 +2300,7 @@
                         </child>
                         <child>
                           <object class="GtkButton" id="browse_button">
-                            <property name="label" translatable="yes">Browse...</property>
+                            <property name="label" translatable="yes">Browse…</property>
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
                             <property name="receives_default">True</property>
@@ -2636,6 +2614,7 @@
                                 <property name="adjustment">adjustment1</property>
                                 <property name="snap_to_ticks">True</property>
                                 <property name="numeric">True</property>
+                                <signal name="value-changed" handler="frames_behind_changed"/>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -2644,10 +2623,10 @@
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkLabel" id="label136">
+                              <object class="GtkLabel" id="frames_behind_label">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="label" translatable="yes">frames behind</property>
+                                <property name="label" translatable="yes"/>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -2875,7 +2854,7 @@
                             </child>
                             <child>
                               <object class="GtkCheckButton" id="show_indicators">
-                                <property name="label" translatable="yes">Show fast-forward and pause indicators</property>
+                                <property name="label" translatable="yes">Show fast‑forward and pause indicators</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="receives_default">False</property>
@@ -2916,7 +2895,7 @@
                                   <object class="GtkLabel" id="osdlabel">
                                     <property name="visible">True</property>
                                    <property name="can_focus">False</property>
-                                   <property name="label" translatable="yes">On-screen display size:</property>
+                                   <property name="label" translatable="yes">On‑screen display size:</property>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
@@ -2927,7 +2906,7 @@
                                   <object class="GtkSpinButton" id="osd_size">
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
-                                    <property name="tooltip_text" translatable="yes">Connect to specified TCP port on remote computer</property>
+                                    <property name="tooltip_text" translatable="yes">The size of on‑screen display messages in pixels</property>
                                     <property name="primary_icon_activatable">False</property>
                                     <property name="secondary_icon_activatable">False</property>
                                     <property name="primary_icon_sensitive">True</property>
@@ -3107,7 +3086,7 @@
                                         </child>
                                         <child>
                                           <object class="GtkCheckButton" id="maintain_aspect_ratio">
-                                            <property name="label" translatable="yes">Maintain aspect-ratio</property>
+                                            <property name="label" translatable="yes">Maintain aspect ratio</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">True</property>
                                             <property name="receives_default">False</property>
@@ -3126,13 +3105,13 @@
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
                                             <property name="spacing">5</property>
+                                            <property name="tooltip-text" translatable="yes">Allows scaling and filtering to use multiple processors</property>
                                             <child>
                                               <object class="GtkCheckButton" id="multithreading">
-                                                <property name="label" translatable="yes">Use </property>
+                                                <property name="label" translatable="yes">Use</property>
                                                 <property name="visible">True</property>
                                                 <property name="can_focus">True</property>
                                                 <property name="receives_default">False</property>
-                                                <property name="tooltip_text" translatable="yes">Allows scaling and filtering to use multiple processors</property>
                                                 <property name="use_underline">True</property>
                                                 <property name="draw_indicator">True</property>
                                               </object>
@@ -3153,6 +3132,7 @@
                                                 <property name="adjustment">adjustment17</property>
                                                 <property name="snap_to_ticks">True</property>
                                                 <property name="numeric">True</property>
+                                                <signal name="value-changed" handler="num_threads_changed"/>
                                               </object>
                                               <packing>
                                                 <property name="expand">False</property>
@@ -3161,10 +3141,9 @@
                                               </packing>
                                             </child>
                                             <child>
-                                              <object class="GtkLabel" id="label126">
+                                              <object class="GtkLabel" id="threads_for_filtering_and_scaling_label">
                                                 <property name="visible">True</property>
                                                 <property name="can_focus">False</property>
-                                                <property name="label" translatable="yes">threads for filtering and scaling</property>
                                               </object>
                                               <packing>
                                                 <property name="expand">False</property>
@@ -3188,7 +3167,7 @@
                                               <object class="GtkLabel" id="label124">
                                                 <property name="visible">True</property>
                                                 <property name="can_focus">False</property>
-                                                <property name="label" translatable="yes">High-resolution effect:</property>
+                                                <property name="label" translatable="yes">High‑resolution effect:</property>
                                               </object>
                                               <packing>
                                                 <property name="expand">False</property>
@@ -3327,7 +3306,7 @@
                                                 </child>
                                                 <child>
                                                   <object class="GtkButton" id="ntsc_svideo_preset">
-                                                    <property name="label" translatable="yes">S-Video</property>
+                                                    <property name="label" translatable="yes">S‑Video</property>
                                                     <property name="visible">True</property>
                                                     <property name="can_focus">True</property>
                                                     <property name="receives_default">True</property>
@@ -3896,7 +3875,7 @@
                             <child>
                               <object class="GtkComboBox" id="hw_accel">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can_focus">True</property>
                                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                 <property name="model">liststore9</property>
                                 <signal name="changed" handler="hw_accel_changed" swapped="no"/>
@@ -3915,7 +3894,7 @@
                             </child>
                             <child>
                               <object class="GtkCheckButton" id="bilinear_filter">
-                                <property name="label" translatable="yes">Bilinear-filter output</property>
+                                <property name="label" translatable="yes">Bilinear‐filter output</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="receives_default">False</property>
@@ -3930,7 +3909,7 @@
                             </child>
                              <child>
                               <object class="GtkCheckButton" id="auto_vrr">
-                                <property name="label" translatable="yes">Use best settings for FreeSync/G-Sync when fullscreen</property>
+                                <property name="label" translatable="yes">Use best settings for FreeSync/G‑Sync when in fullscreen</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="receives_default">False</property>
@@ -4019,7 +3998,7 @@
                                     </child>
                                     <child>
                                       <object class="GtkButton" id="fragment_shader_button">
-                                        <property name="label" translatable="yes">Browse...</property>
+                                        <property name="label" translatable="yes">Browse…</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">True</property>
@@ -4051,11 +4030,11 @@
                                 <property name="can_focus">False</property>
                                 <child>
                                   <object class="GtkCheckButton" id="force_inverted_byte_order">
-                                    <property name="label" translatable="yes">Force an inverted byte-ordering</property>
+                                    <property name="label" translatable="yes">Force an inverted byte‑ordering</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
                                     <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Forces a swapped byte-ordering for cases where the system's endian is used instead of the video card</property>
+                                    <property name="tooltip_text" translatable="yes">Forces a swapped byte‑ordering for cases where the system’s endian is used instead of the video card</property>
                                     <property name="draw_indicator">True</property>
                                   </object>
                                   <packing>
@@ -4200,7 +4179,7 @@
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">False</property>
-                                        <property name="tooltip_text" translatable="yes">Sets the correct input rate based on the display's refresh rate</property>
+                                        <property name="tooltip_text" translatable="yes">Sets the correct input rate based on the display’s refresh rate</property>
                                         <property name="draw_indicator">True</property>
                                         <signal name="toggled" handler="auto_input_rate_toggled" swapped="no"/>
                                       </object>
@@ -4294,6 +4273,7 @@
                                                 <property name="snap_to_ticks">True</property>
                                                 <property name="width_chars">6</property>
                                                 <property name="numeric">True</property>
+                                                <signal name="value-changed" handler="sound_buffer_size_changed"/>
                                               </object>
                                               <packing>
                                                 <property name="expand">False</property>
@@ -4302,10 +4282,9 @@
                                               </packing>
                                             </child>
                                             <child>
-                                              <object class="GtkLabel" id="label137">
+                                              <object class="GtkLabel" id="milliseconds_label">
                                                 <property name="visible">True</property>
                                                 <property name="can_focus">False</property>
-                                                <property name="label" translatable="yes">milliseconds</property>
                                               </object>
                                               <packing>
                                                 <property name="expand">False</property>
@@ -4400,11 +4379,12 @@
                                           <object class="GtkHScale" id="sound_input_rate">
                                             <property name="visible">True</property>
                                             <property name="can_focus">True</property>
-                                            <property name="tooltip_text" translatable="yes">Adjust to produce more or less data. Decrease the rate if experiencing crackling. Increase the rate if experiencing frame-rate stuttering. Best used with the "Synchronize with sound" option</property>
+                                            <property name="tooltip_text" translatable="yes">Adjust to produce more or less data. Decrease the rate if experiencing crackling. Increase the rate if experiencing frame rate stuttering. Best used with the “Sound buffer synchronization” option.</property>
                                             <property name="adjustment">adjustment5</property>
                                             <property name="restrict_to_fill_level">False</property>
-                                            <property name="digits">0</property>
+                                            <property name="digits">8</property>
                                             <property name="value_pos">left</property>
+                                            <signal name="format_value" handler="format_sound_input_rate_value"/>
                                           </object>
                                           <packing>
                                             <property name="left_attach">1</property>
@@ -4445,7 +4425,7 @@
                                           </packing>
                                         </child>
                                         <child>
-                                          <object class="GtkLabel" id="label139">
+                                          <object class="GtkLabel" id="video_rate_label">
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
                                             <property name="xalign">0</property>
@@ -4462,7 +4442,6 @@
                                           <object class="GtkLabel" id="relative_video_rate">
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">label</property>
                                           </object>
                                           <packing>
                                             <property name="left_attach">1</property>
@@ -5134,7 +5113,7 @@
                                     </child>
                                     <child>
                                       <object class="GtkButton" id="sram_browse">
-                                        <property name="label" translatable="yes">Browse...</property>
+                                        <property name="label" translatable="yes">Browse…</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">True</property>
@@ -5149,7 +5128,7 @@
                                     </child>
                                     <child>
                                       <object class="GtkButton" id="savestate_browse">
-                                        <property name="label" translatable="yes">Browse...</property>
+                                        <property name="label" translatable="yes">Browse…</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">True</property>
@@ -5166,7 +5145,7 @@
                                     </child>
                                     <child>
                                       <object class="GtkButton" id="cheat_browse">
-                                        <property name="label" translatable="yes">Browse...</property>
+                                        <property name="label" translatable="yes">Browse…</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">True</property>
@@ -5183,7 +5162,7 @@
                                     </child>
                                     <child>
                                       <object class="GtkButton" id="patch_browse">
-                                        <property name="label" translatable="yes">Browse...</property>
+                                        <property name="label" translatable="yes">Browse…</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">True</property>
@@ -5200,7 +5179,7 @@
                                     </child>
                                     <child>
                                       <object class="GtkButton" id="export_browse">
-                                        <property name="label" translatable="yes">Browse...</property>
+                                        <property name="label" translatable="yes">Browse…</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">True</property>
@@ -5340,17 +5319,13 @@
                                   </packing>
                                 </child>
                                 <child>
-                                  <object class="GtkEntry" id="save_sram_after_sec">
+                                  <object class="GtkSpinButton" id="save_sram_after_sec">
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
-                                    <property name="tooltip_text" translatable="yes">Automatically save the game's SRAM at this interval. Setting this to 0 will only save when quitting or changing ROMs</property>
-                                    <property name="invisible_char">•</property>
-                                    <property name="width_chars">5</property>
-                                    <property name="xalign">1</property>
-                                    <property name="primary_icon_activatable">False</property>
-                                    <property name="secondary_icon_activatable">False</property>
-                                    <property name="primary_icon_sensitive">True</property>
-                                    <property name="secondary_icon_sensitive">True</property>
+                                    <property name="tooltip_text" translatable="yes">Automatically save the game’s SRAM at this interval. Setting this to 0 will only save when quitting or changing ROMs</property>
+                                    <property name="numeric">True</property>
+                                    <property name="adjustment">save_sram_after_sec_adjustment</property>
+                                    <signal name="value-changed" handler="save_sram_after_sec_value_changed"/>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
@@ -5359,10 +5334,9 @@
                                   </packing>
                                 </child>
                                 <child>
-                                  <object class="GtkLabel" id="label12">
+                                  <object class="GtkLabel" id="save_sram_after_sec_label">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
-                                    <property name="label" translatable="yes">seconds after change</property>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
@@ -5565,13 +5539,14 @@
                     </child>
                     <child>
                       <object class="GtkCheckButton" id="use_modifiers">
-                        <property name="label" translatable="yes">Use modifier keys (CTRL, SHIFT, ALT) directly</property>
+                        <property name="label" translatable="yes">Use _modifier keys (Ctrl, Shift, Alt) directly</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">False</property>
                         <property name="tooltip_text" translatable="yes">Allow using modifier keys as independent keys instead of modifiers</property>
                         <property name="active">True</property>
                         <property name="draw_indicator">True</property>
+                        <property name="use_underline">True</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -6700,7 +6675,7 @@
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="label" translatable="yes">&lt;small&gt;Click an entry and then press the desired keys or joystick button
-&lt;i&gt;Escape&lt;/i&gt;: Move to next&lt;i&gt;  Shift-Escape&lt;/i&gt;: Clear selected&lt;/small&gt;</property>
+&lt;tt&gt;Escape&lt;/tt&gt;: Move to next  &lt;tt&gt;Shift+Escape&lt;/tt&gt;: Clear selected&lt;/small&gt;</property>
                         <property name="use_markup">True</property>
                         <property name="justify">fill</property>
                         <property name="wrap">True</property>
@@ -9052,7 +9027,7 @@
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="label" translatable="yes">&lt;small&gt;Click an entry and then press the desired keys or joystick button
-&lt;i&gt;Escape&lt;/i&gt;: Move to next&lt;i&gt;  Shift-Escape&lt;/i&gt;: Clear selected&lt;/small&gt;</property>
+&lt;tt&gt;Escape&lt;/tt&gt;: Move to next  &lt;tt&gt;Shift+Escape&lt;/tt&gt;: Clear selected&lt;/small&gt;</property>
                         <property name="use_markup">True</property>
                         <property name="justify">fill</property>
                         <property name="wrap">True</property>
@@ -9142,7 +9117,7 @@
                                 </child>
                                 <child>
                                   <object class="GtkCheckButton" id="force_enable_icons">
-                                    <property name="label" translatable="yes">Force-enable button and menu icons</property>
+                                    <property name="label" translatable="yes">Force‑enable button and menu icons</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
                                     <property name="receives_default">False</property>
@@ -9163,7 +9138,9 @@
                                       <object class="GtkLabel" id="label128">
                                         <property name="visible">True</property>
                                         <property name="can_focus">False</property>
-                                        <property name="label" translatable="yes">The ESC key should:</property>
+                                        <property name="label" translatable="yes">The &lt;tt&gt;Esc&lt;/tt&gt; key should:</property>
+                                        <property name="use_markup">True</property>
+                                        <property name="use_underline">True</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -9364,19 +9341,19 @@
     </action-widgets>
   </object>
   <object class="GtkTextBuffer" id="textbuffer1">
-    <property name="text" translatable="yes">  Snes9x - Portable Super Nintendo Entertainment System (TM) emulator.
+    <property name="text" translatable="yes">  Snes9x – A Portable Super Nintendo Entertainment System™ Emulator
 
   Snes9x homepage: http://www.snes9x.com/
   Snes9x source code: https://github.com/snes9xgit/snes9x/
 
   Permission to use, copy, modify and/or distribute Snes9x in both binary
-  and source form, for non-commercial purposes, is hereby granted without
+  and source form, for non‑commercial purposes, is hereby granted without
   fee, providing that this license information and copyright notice appear
   with all copies and any derived work.
 
-  This software is provided 'as-is', without any express or implied
+  This software is provided ‘as‑is’, without any express or implied
   warranty. In no event shall the authors be held liable for any damages
-  arising from the use of this software or it's derivatives.
+  arising from the use of this software or it’s derivatives.
 
   Snes9x is freeware for PERSONAL USE only. Commercial users should
   seek permission of the copyright holders first. Commercial use includes,


### PR DESCRIPTION
* Add plurals
* Drop proper names from l10n
* Add string parameter numbers for correct l10n freedom
* Update POT file
* Update pl l10n based on new POT file
* Add locale specific number formatting where applicable
* Make use of [Glib’s logging](https://docs.gtk.org/glib/logging.html) facility

It still is not perfect or complete but the majority of usually user visible messages are taken care of.