### PR TITLE
gtk: Use CMAKE_DL_LIBS

### DIFF
--- a/gtk/CMakeLists.txt
+++ b/gtk/CMakeLists.txt
@@ -64,9 +64,8 @@ pkg_check_modules(XRANDR REQUIRED xrandr)
 
 find_library(X11 X11 REQUIRED)
 find_library(XEXT Xext REQUIRED)
-find_library(DL dl REQUIRED)
 list(APPEND ARGS ${SDL2_CFLAGS} ${GTK_CFLAGS} ${XRANDR_CFLAGS})
-list(APPEND LIBS ${X11} ${XEXT} ${DL} ${SDL2_LIBRARIES} ${GTK_LIBRARIES} ${XRANDR_LIBRARIES})
+list(APPEND LIBS ${X11} ${XEXT} ${CMAKE_DL_LIBS} ${SDL2_LIBRARIES} ${GTK_LIBRARIES} ${XRANDR_LIBRARIES})
 
 list(APPEND SOURCES src/gtk_display_driver_opengl.cpp
                     ../common/video/glx_context.cpp


### PR DESCRIPTION
Fixes building snes9x-gtk on systems where dlopen is in libc and without an empty libdl stub.