### PR TITLE
Gtk: Fix build on 32-bits systems.

### DIFF
--- a/gtk/src/gtk_display_driver_vulkan.cpp
+++ b/gtk/src/gtk_display_driver_vulkan.cpp
@@ -66,12 +66,12 @@ bool S9xVulkanDisplayDriver::init_imgui()
     init_info.Device = context->device;;
     init_info.QueueFamily = context->graphics_queue_family_index;
     init_info.Queue = context->queue;
-    init_info.DescriptorPool = imgui_descriptor_pool.get();
+    init_info.DescriptorPool = static_cast<VkDescriptorPool>(imgui_descriptor_pool.get());
     init_info.Subpass = 0;
     init_info.MinImageCount = context->swapchain->get_num_frames();
     init_info.ImageCount = context->swapchain->get_num_frames();
     init_info.MSAASamples = VK_SAMPLE_COUNT_1_BIT;
-    ImGui_ImplVulkan_Init(&init_info, context->swapchain->get_render_pass());
+    ImGui_ImplVulkan_Init(&init_info, static_cast<VkRenderPass>(context->swapchain->get_render_pass()));
 
     auto cmd = context->begin_cmd_buffer();
     ImGui_ImplVulkan_CreateFontsTexture(cmd);


### PR DESCRIPTION
As the title says. The actual error we ran into is

```
/usr/ports/pobj/snes9x-1.63/bin/c++ -DALLOW_CPU_OVERCLOCK -DDATADIR=\"/usr/local/share/snes9x\" -DGETTEXT_PACKAGE=\"snes9x-gtk\" -DHAVE_LIBPNG -DHAVE_MKSTEMP -DHAVE_STDINT_H -DHAVE_STRINGS_H -DIMGUI_IMPL_VULKAN_NO_PROTOTYPES -DJMA_SUPPORT -DNETPLAY_SUPPORT -DRIGHTSHIFT_IS_SAR -DSNES9XLOCALEDIR=\"/usr/local/share/locale\" -DSNES9X_GTK -DUNZIP_SUPPORT -DUSE_HQ2X -DUSE_SLANG -DUSE_XBRZ -DUSE_XV -DVK_USE_PLATFORM_XLIB_KHR -DVMA_DYNAMIC_VULKAN_FUNCTIONS=1 -DVMA_STATIC_VULKAN_FUNCTIONS=0 -DVULKAN_HPP_DISPATCH_LOADER_DYNAMIC=1 -DVULKAN_HPP_NO_EXCEPTIONS=1 -DVULKAN_HPP_NO_NODISCARD_WARNINGS=1 -DZLIB -I/usr/ports/pobj/snes9x-1.63/snes9x-1.63/gtk/../apu/bapu -I/usr/ports/pobj/snes9x-1.63/snes9x-1.63/gtk/.. -I/usr/ports/pobj/snes9x-1.63/snes9x-1.63/gtk/src -I/usr/ports/pobj/snes9x-1.63/snes9x-1.63/gtk/../external/glad/include -I/usr/ports/pobj/snes9x-1.63/snes9x-1.63/gtk/../external/vulkan-headers/include -I/usr/ports/pobj/snes9x-1.63/snes9x-1.63/gtk/../external/VulkanMemoryAllocator-Hpp/include -I/usr/ports/pobj/snes9x-1.63/snes9x-1.63/gtk/../external/stb -I/usr/ports/pobj/snes9x-1.63/snes9x-1.63/gtk/../external/imgui -I/usr/ports/pobj/snes9x-1.63/snes9x-1.63/gtk/../unzip -I/usr/ports/pobj/snes9x-1.63/snes9x-1.63/gtk/../external/fmt/include -O2 -pipe  -I/usr/local/include -DNDEBUG -std=gnu++17 -Wall -Wno-unused-parameter -Wno-unused-variable -I/usr/local/include/SDL2 -I/usr/X11R6/include -D_REENTRANT -I/usr/local/include/gtkmm-3.0 -I/usr/local/lib/gtkmm-3.0/include -I/usr/local/include/atkmm-1.6 -I/usr/local/lib/atkmm-1.6/include -I/usr/local/include/gtk-3.0/unix-print -I/usr/local/include/gdkmm-3.0 -I/usr/local/lib/gdkmm-3.0/include -I/usr/local/include/giomm-2.4 -I/usr/local/lib/giomm-2.4/include -I/usr/local/include/gtk-3.0 -I/usr/local/include/at-spi2-atk/2.0 -I/usr/local/include/at-spi-2.0 -I/usr/local/include/dbus-1.0 -I/usr/local/lib/dbus-1.0/include -I/usr/local/include -I/usr/local/include/gio-unix-2.0 -I/usr/local/include/libepoll-shim -I/usr/X11R6/include/libdrm -I/usr/local/include/atk-1.0 -I/usr/local/include/cairo -I/usr/local/include/pangomm-1.4 -I/usr/local/lib/pangomm-1.4/include -I/usr/local/include/glibmm-2.4 -I/usr/local/lib/glibmm-2.4/include -I/usr/local/include/cairomm-1.0 -I/usr/local/lib/cairomm-1.0/include -I/usr/local/include/sigc++-2.0 -I/usr/local/lib/sigc++-2.0/include -I/usr/local/include/pango-1.0 -I/usr/local/include/harfbuzz -I/usr/local/include/fribidi -I/usr/X11R6/include/freetype2 -I/usr/X11R6/include/pixman-1 -I/usr/local/include/gdk-pixbuf-2.0 -pthread -I/usr/local/include/glib-2.0 -I/usr/local/lib/glib-2.0/include -I/usr/local/include/libpng16 -MD -MT CMakeFiles/snes9x-gtk.dir/src/gtk_display_driver_vulkan.cpp.o -MF CMakeFiles/snes9x-gtk.dir/src/gtk_display_driver_vulkan.cpp.o.d -o CMakeFiles/snes9x-gtk.dir/src/gtk_display_driver_vulkan.cpp.o -c /usr/ports/pobj/snes9x-1.63/snes9x-1.63/gtk/src/gtk_display_driver_vulkan.cpp
/usr/ports/pobj/snes9x-1.63/snes9x-1.63/gtk/src/gtk_display_driver_vulkan.cpp:69:54: error: assigning to 'VkDescriptorPool' (aka 'unsigned long long') from incompatible type 'vk::DescriptorPool'
    init_info.DescriptorPool = imgui_descriptor_pool.get();
                               ~~~~~~~~~~~~~~~~~~~~~~^~~~~
/usr/ports/pobj/snes9x-1.63/snes9x-1.63/gtk/src/gtk_display_driver_vulkan.cpp:74:5: error: no matching function for call to 'ImGui_ImplVulkan_Init'
    ImGui_ImplVulkan_Init(&init_info, context->swapchain->get_render_pass());
    ^~~~~~~~~~~~~~~~~~~~~
/usr/ports/pobj/snes9x-1.63/snes9x-1.63/gtk/../external/imgui/imgui_impl_vulkan.h:67:29: note: candidate function not viable: no known conversion from 'vk::RenderPass' to 'VkRenderPass' (aka 'unsigned long long') for 2nd argument
IMGUI_IMPL_API bool         ImGui_ImplVulkan_Init(ImGui_ImplVulkan_InitInfo* info, VkRenderPass render_pass);
                            ^
2 errors generated.
ninja: build stopped: subcommand failed.
```

Solution is taken from https://github.com/KhronosGroup/Vulkan-Hpp#cc-interop-for-handles .

See https://marc.info/?l=openbsd-ports&m=172164407618851&w=2 and follow-up for context.

In particular, as detailed in the follow-up, I only compile-tested this. I don't know if 32-bits runtime works. 64-bits runtime is unaffected by this and it still builds with the patch.