### PR TITLE
New Interpolation Filters

### DIFF
--- a/filter/filter_bicubic_win.cpp
+++ b/filter/filter_bicubic_win.cpp
@@ -13,7 +13,7 @@ static uint8_t gamma_decode[256];
 
 static void init_gamma_tables()
 {
-    constexpr float gamma = 1.55f;
+    constexpr float gamma = 1.8f;
     constexpr float inv_gamma = 1.0f / gamma;
 
     for (int i = 0; i < 32; ++i)

--- a/filter/filter_bicubic_win.cpp
+++ b/filter/filter_bicubic_win.cpp
@@ -13,7 +13,7 @@ static uint8_t gamma_decode[256];
 
 static void init_gamma_tables()
 {
-    constexpr float gamma = 1.5f;
+    constexpr float gamma = 1.45f;
     constexpr float inv_gamma = 1.0f / gamma;
 
     for (int i = 0; i < 32; ++i)
@@ -28,7 +28,7 @@ inline int hermite_weight(int t_fp)
 {
     int t = (t_fp > FP_ONE) ? FP_ONE : t_fp;
     int inv = FP_ONE - t;
-    return (inv * inv) >> FP_SHIFT; // Full quadratic
+    return ((inv * inv * (FP_ONE + (t >> 1))) >> FP_SHIFT) >> FP_SHIFT; // Softer (approx. 2/3)
 }
 
 inline uint16_t build_rgb565_fast(int r, int g, int b)

--- a/filter/filter_bicubic_win.cpp
+++ b/filter/filter_bicubic_win.cpp
@@ -13,7 +13,7 @@ static uint8_t gamma_decode[256];
 
 static void init_gamma_tables()
 {
-    constexpr float gamma = 1.45f;
+    constexpr float gamma = 1.55f;
     constexpr float inv_gamma = 1.0f / gamma;
 
     for (int i = 0; i < 32; ++i)

--- a/filter/filter_bicubic_win.cpp
+++ b/filter/filter_bicubic_win.cpp
@@ -13,7 +13,7 @@ static uint8_t gamma_decode[256];
 
 static void init_gamma_tables()
 {
-    constexpr float gamma = 1.8f;
+    constexpr float gamma = 1.6f;
     constexpr float inv_gamma = 1.0f / gamma;
 
     for (int i = 0; i < 32; ++i)

--- a/filter/filter_bicubic_win.cpp
+++ b/filter/filter_bicubic_win.cpp
@@ -1,0 +1,162 @@
+#include <cstdint>
+#include <cstring>
+#include <algorithm>
+#include <cmath>
+
+#define FP_SHIFT 8
+#define FP_ONE   (1 << FP_SHIFT)
+#define CLAMP_U8(x, lo, hi) ((x) < (lo) ? (lo) : ((x) > (hi) ? (hi) : (x)))
+
+static uint8_t gamma_r_encode[32];
+static uint8_t gamma_g_encode[64];
+static uint8_t gamma_decode[256];
+
+static void init_gamma_tables()
+{
+    constexpr float gamma = 1.5f;
+    constexpr float inv_gamma = 1.0f / gamma;
+
+    for (int i = 0; i < 32; ++i)
+        gamma_r_encode[i] = uint8_t(CLAMP_U8(int(std::pow((i << 3) / 255.0f, gamma) * 255.0f + 0.5f), 0, 255));
+    for (int i = 0; i < 64; ++i)
+        gamma_g_encode[i] = uint8_t(CLAMP_U8(int(std::pow((i << 2) / 255.0f, gamma) * 255.0f + 0.5f), 0, 255));
+    for (int i = 0; i < 256; ++i)
+        gamma_decode[i] = uint8_t(CLAMP_U8(int(std::pow(i / 255.0f, inv_gamma) * 255.0f + 0.5f), 0, 255));
+}
+
+inline int hermite_weight(int t_fp)
+{
+    int t = (t_fp > FP_ONE) ? FP_ONE : t_fp;
+    int inv = FP_ONE - t;
+    return (inv * inv) >> FP_SHIFT; // Full quadratic
+}
+
+inline uint16_t build_rgb565_fast(int r, int g, int b)
+{
+    return ((r & 0xF8) << 8) | ((g & 0xFC) << 3) | (b >> 3);
+}
+
+extern "C"
+void ApplyBicubic4x(
+    uint8_t* __restrict dst,
+    int dst_width,
+    int dst_height,
+    int dst_pitch,
+    const uint8_t* __restrict src,
+    int src_width,
+    int src_height,
+    int src_pitch)
+{
+    constexpr int scale = 4;
+    const uint16_t* __restrict src16 = reinterpret_cast<const uint16_t*>(src);
+    uint16_t* __restrict dst16 = reinterpret_cast<uint16_t*>(dst);
+    int src_pitch16 = src_pitch / 2;
+    int dst_pitch16 = dst_pitch / 2;
+
+    static bool gamma_ready = false;
+    if (!gamma_ready) {
+        init_gamma_tables();
+        gamma_ready = true;
+    }
+
+    int weights[scale][scale][4][4];
+    uint16_t inv_weight_sums[scale][scale];
+
+    for (int dy = 0; dy < scale; ++dy) {
+        int sy_fp = ((dy << FP_SHIFT) / scale);
+        for (int dx = 0; dx < scale; ++dx) {
+            int sx_fp = ((dx << FP_SHIFT) / scale);
+            int sum = 0;
+            for (int m = 0; m < 4; ++m) {
+                int wy = hermite_weight(std::abs(((m - 1) << FP_SHIFT) - sy_fp));
+                for (int n = 0; n < 4; ++n) {
+                    int wx = hermite_weight(std::abs(((n - 1) << FP_SHIFT) - sx_fp));
+                    int weight = (wx * wy) >> FP_SHIFT;
+                    weights[dy][dx][m][n] = weight;
+                    sum += weight;
+                }
+            }
+            inv_weight_sums[dy][dx] = (sum == 0) ? 65536 : ((65536 + (sum >> 1)) / sum);
+        }
+    }
+
+    for (int y = 0; y < src_height; ++y) {
+        for (int x = 0; x < src_width; ++x) {
+            bool is_center = x > 2 && x < src_width - 3 && y > 2 && y < src_height - 3;
+            uint16_t neighborhood[4][4];
+            uint8_t r8[4][4], g8[4][4], b8[4][4];
+
+            if (is_center) {
+                const uint16_t* row0 = src16 + (y - 1) * src_pitch16;
+                const uint16_t* row1 = src16 + (y + 0) * src_pitch16;
+                const uint16_t* row2 = src16 + (y + 1) * src_pitch16;
+                const uint16_t* row3 = src16 + (y + 2) * src_pitch16;
+                for (int i = 0; i < 4; ++i) {
+                    int dx = i - 1;
+                    neighborhood[0][i] = row0[x + dx];
+                    neighborhood[1][i] = row1[x + dx];
+                    neighborhood[2][i] = row2[x + dx];
+                    neighborhood[3][i] = row3[x + dx];
+                }
+            }
+            else {
+                int clamped_x[4];
+                int clamped_y[4];
+                const uint16_t* src_rows[4];
+
+                for (int j = 0; j < 4; ++j) {
+                    clamped_y[j] = std::clamp(y + j - 1, 0, src_height - 1);
+                    src_rows[j] = src16 + clamped_y[j] * src_pitch16;
+                }
+                for (int i = 0; i < 4; ++i) {
+                    clamped_x[i] = std::clamp(x + i - 1, 0, src_width - 1);
+                }
+
+                for (int j = 0; j < 4; ++j) {
+                    for (int i = 0; i < 4; ++i) {
+                        neighborhood[j][i] = src_rows[j][clamped_x[i]];
+                    }
+                }
+            }
+
+            for (int j = 0; j < 4; ++j) {
+                for (int i = 0; i < 4; ++i) {
+                    uint16_t p = neighborhood[j][i];
+                    r8[j][i] = gamma_r_encode[(p >> 11) & 0x1F];
+                    g8[j][i] = gamma_g_encode[(p >> 5) & 0x3F];
+                    b8[j][i] = gamma_r_encode[p & 0x1F];
+                }
+            }
+
+            for (int dy = 0; dy < scale; ++dy) {
+                for (int dx = 0; dx < scale; ++dx) {
+                    int r_sum = 0, g_sum = 0, b_sum = 0;
+                    int (*w)[4] = weights[dy][dx];
+                    for (int j = 0; j < 4; ++j) {
+                        for (int i = 0; i < 4; ++i) {
+                            int weight = w[j][i];
+                            r_sum += r8[j][i] * weight;
+                            g_sum += g8[j][i] * weight;
+                            b_sum += b8[j][i] * weight;
+                        }
+                    }
+                    uint16_t norm = inv_weight_sums[dy][dx];
+                    int r_final = gamma_decode[(r_sum * norm) >> 16];
+                    int g_final = gamma_decode[(g_sum * norm) >> 16];
+                    int b_final = gamma_decode[(b_sum * norm) >> 16];
+
+                    dst16[(y * scale + dy) * dst_pitch16 + (x * scale + dx)] =
+                        build_rgb565_fast(r_final, g_final, b_final);
+                }
+            }
+        }
+    }
+}
+
+extern "C"
+void filter_bicubic4x_standard(uint8_t* srcPtr, int srcPitch, uint8_t* dstPtr, int dstPitch,
+    int width, int height)
+{
+    ApplyBicubic4x(dstPtr, width * 4, height * 4, dstPitch,
+        srcPtr, width, height, srcPitch);
+}

--- a/filter/filter_bicubic_win.h
+++ b/filter/filter_bicubic_win.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void ApplyBicubic4x(uint8_t* dst, int dst_width, int dst_height, int dst_pitch, const uint8_t* src, int src_width, int src_height, int src_pitch);
+void filter_bicubic4x_standard(uint8_t* srcPtr, int srcPitch, uint8_t* dstPtr, int dstPitch, int srcWidth, int srcHeight);
+
+#ifdef __cplusplus
+}
+#endif

--- a/filter/filter_lanczos.cpp
+++ b/filter/filter_lanczos.cpp
@@ -51,7 +51,7 @@ void ApplyLanczos4x(
     int src_pitch16 = src_pitch / 2;
     int dst_pitch16 = dst_pitch / 2;
 
-    constexpr float black_factor = 0.48f;
+    constexpr float black_factor = 0.45f;
 
     // Build weight tables
     int16_t w_table[2][scale * scale * kernel_size * kernel_size];

--- a/filter/filter_lanczos.cpp
+++ b/filter/filter_lanczos.cpp
@@ -1,0 +1,165 @@
+#include <cstdint>
+#include <cstring>
+#include <algorithm>
+#include <cmath>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+#define FP_SHIFT 8
+#define FP_ONE   (1 << FP_SHIFT)
+#define CLAMP_U8(x) ((x) < 0 ? 0 : ((x) > 255 ? 255 : (x)))
+
+inline float sinc(float x)
+{
+    if (x == 0.0f) return 1.0f;
+    x *= float(M_PI);
+    return std::sinf(x) / x;
+}
+
+inline int lanczos2_weight_fp(int t_fp)
+{
+    constexpr float radius = 0.6f;
+    float t = float(t_fp) / float(FP_ONE);
+    if (std::abs(t) >= radius) return 0;
+    float w = sinc(t) * sinc(t / radius);
+    return int(w * FP_ONE + 0.5f);
+}
+
+inline uint16_t build_rgb565_fast(int r, int g, int b)
+{
+    return ((r & 0xF8) << 8) | ((g & 0xFC) << 3) | (b >> 3);
+}
+
+extern "C"
+void ApplyLanczos4x(
+    uint8_t* __restrict dst,
+    int dst_width,
+    int dst_height,
+    int dst_pitch,
+    const uint8_t* __restrict src,
+    int src_width,
+    int src_height,
+    int src_pitch)
+{
+    constexpr int scale = 4;
+    constexpr int kernel_size = 4;
+    constexpr int half_kernel = kernel_size / 2;
+    const uint16_t* __restrict src16 = reinterpret_cast<const uint16_t*>(src);
+    uint16_t* __restrict dst16 = reinterpret_cast<uint16_t*>(dst);
+    int src_pitch16 = src_pitch / 2;
+    int dst_pitch16 = dst_pitch / 2;
+
+    constexpr float black_factor = 0.48f;
+
+    // Build weight tables
+    int16_t w_table[2][scale * scale * kernel_size * kernel_size];
+    uint16_t inv_weight_sums[scale][scale];
+
+    for (int dy = 0; dy < scale; ++dy) {
+        int sy_fp = ((dy << FP_SHIFT) / scale);
+        for (int dx = 0; dx < scale; ++dx) {
+            int sx_fp = ((dx << FP_SHIFT) / scale);
+            int base_sum = 0;
+            int16_t* base_block = &w_table[0][(dy * scale + dx) * kernel_size * kernel_size];
+            int16_t* black_block = &w_table[1][(dy * scale + dx) * kernel_size * kernel_size];
+
+            for (int j = 0; j < kernel_size; ++j) {
+                int wy = lanczos2_weight_fp(((j - half_kernel) << FP_SHIFT) - sy_fp);
+                for (int i = 0; i < kernel_size; ++i) {
+                    int wx = lanczos2_weight_fp(((i - half_kernel) << FP_SHIFT) - sx_fp);
+                    int weight = (wx * wy) >> FP_SHIFT;
+                    base_block[j * kernel_size + i] = static_cast<int16_t>(weight);
+                    black_block[j * kernel_size + i] = static_cast<int16_t>(weight * black_factor + 0.5f);
+                    base_sum += weight;
+                }
+            }
+
+            inv_weight_sums[dy][dx] = (base_sum == 0) ? 65536 : ((65536 + (base_sum >> 1)) / base_sum);
+        }
+    }
+
+    for (int y = 0; y < src_height; ++y) {
+        for (int x = 0; x < src_width; ++x) {
+            uint8_t rgb[kernel_size][kernel_size][3];
+            uint8_t is_black[kernel_size][kernel_size];
+            bool has_black = false;
+
+            for (int j = 0; j < kernel_size; ++j) {
+                int sy = std::clamp(y + j - half_kernel, 0, src_height - 1);
+                const uint16_t* row = src16 + sy * src_pitch16;
+                for (int i = 0; i < kernel_size; ++i) {
+                    int sx = std::clamp(x + i - half_kernel, 0, src_width - 1);
+                    uint16_t p = row[sx];
+                    uint8_t r = (p >> 11) & 0x1F;
+                    uint8_t g = (p >> 5) & 0x3F;
+                    uint8_t b = p & 0x1F;
+                    r = (r << 3) | (r >> 2);
+                    g = (g << 2) | (g >> 4);
+                    b = (b << 3) | (b >> 2);
+                    rgb[j][i][0] = r;
+                    rgb[j][i][1] = g;
+                    rgb[j][i][2] = b;
+                    bool black = (r | g | b) == 0;
+                    is_black[j][i] = black;
+                    has_black |= black;
+                }
+            }
+
+            for (int dy = 0; dy < scale; ++dy) {
+                for (int dx = 0; dx < scale; ++dx) {
+                    int r_sum = 0, g_sum = 0, b_sum = 0, weight_sum = 0;
+                    int block_idx = (dy * scale + dx) * kernel_size * kernel_size;
+                    const int16_t* base_block = &w_table[0][block_idx];
+                    const int16_t* black_block = &w_table[1][block_idx];
+
+                    if (!has_black) {
+                        // Fast path
+                        for (int j = 0; j < kernel_size; ++j) {
+                            for (int i = 0; i < kernel_size; ++i) {
+                                int w = base_block[j * kernel_size + i];
+                                r_sum += rgb[j][i][0] * w;
+                                g_sum += rgb[j][i][1] * w;
+                                b_sum += rgb[j][i][2] * w;
+                            }
+                        }
+                        int norm = inv_weight_sums[dy][dx];
+                        int r_final = CLAMP_U8((r_sum * norm) >> 16);
+                        int g_final = CLAMP_U8((g_sum * norm) >> 16);
+                        int b_final = CLAMP_U8((b_sum * norm) >> 16);
+                        dst16[(y * scale + dy) * dst_pitch16 + (x * scale + dx)] =
+                            build_rgb565_fast(r_final, g_final, b_final);
+                    }
+                    else {
+                        // Slow path with true black weight attenuation
+                        for (int j = 0; j < kernel_size; ++j) {
+                            for (int i = 0; i < kernel_size; ++i) {
+                                int index = j * kernel_size + i;
+                                int w = base_block[index] - ((base_block[index] - black_block[index]) * is_black[j][i]);
+                                r_sum += rgb[j][i][0] * w;
+                                g_sum += rgb[j][i][1] * w;
+                                b_sum += rgb[j][i][2] * w;
+                                weight_sum += w;
+                            }
+                        }
+                        int norm = (weight_sum == 0) ? 1 : ((65536 + (weight_sum >> 1)) / weight_sum);
+                        int r_final = CLAMP_U8((r_sum * norm) >> 16);
+                        int g_final = CLAMP_U8((g_sum * norm) >> 16);
+                        int b_final = CLAMP_U8((b_sum * norm) >> 16);
+                        dst16[(y * scale + dy) * dst_pitch16 + (x * scale + dx)] =
+                            build_rgb565_fast(r_final, g_final, b_final);
+                    }
+                }
+            }
+        }
+    }
+}
+
+extern "C"
+void filter_lanczos4x(uint8_t* srcPtr, int srcPitch, uint8_t* dstPtr, int dstPitch,
+    int width, int height)
+{
+    ApplyLanczos4x(dstPtr, width * 4, height * 4, dstPitch,
+        srcPtr, width, height, srcPitch);
+}

--- a/filter/filter_lanczos.cpp
+++ b/filter/filter_lanczos.cpp
@@ -20,7 +20,7 @@ inline float sinc(float x)
 
 inline int lanczos2_weight_fp(int t_fp)
 {
-    constexpr float radius = 0.6f;
+    constexpr float radius = 1.0f;
     float t = float(t_fp) / float(FP_ONE);
     if (std::abs(t) >= radius) return 0;
     float w = sinc(t) * sinc(t / radius);
@@ -163,3 +163,4 @@ void filter_lanczos4x(uint8_t* srcPtr, int srcPitch, uint8_t* dstPtr, int dstPit
     ApplyLanczos4x(dstPtr, width * 4, height * 4, dstPitch,
         srcPtr, width, height, srcPitch);
 }
+

--- a/filter/filter_sharpbilinear_flexible.cpp
+++ b/filter/filter_sharpbilinear_flexible.cpp
@@ -1,0 +1,114 @@
+#include <cstdint>
+#include <cmath>
+#include <algorithm>
+
+#define CLAMP_U8(x, lo, hi) ((x) < (lo) ? (lo) : ((x) > (hi) ? (hi) : (x)))
+
+static uint8_t gamma_r_encode[32];
+static uint8_t gamma_g_encode[64];
+static uint8_t gamma_decode[256];
+
+static void init_gamma_tables()
+{
+    constexpr float gamma = 1.4f;
+    constexpr float inv_gamma = 1.0f / gamma;
+
+    for (int i = 0; i < 32; ++i)
+        gamma_r_encode[i] = uint8_t(CLAMP_U8(int(std::pow((i << 3) / 255.0f, gamma) * 255.0f + 0.5f), 0, 255));
+    for (int i = 0; i < 64; ++i)
+        gamma_g_encode[i] = uint8_t(CLAMP_U8(int(std::pow((i << 2) / 255.0f, gamma) * 255.0f + 0.5f), 0, 255));
+    for (int i = 0; i < 256; ++i)
+        gamma_decode[i] = uint8_t(CLAMP_U8(int(std::pow(i / 255.0f, inv_gamma) * 255.0f + 0.5f), 0, 255));
+}
+
+static inline uint16_t build_rgb565_fast(int r, int g, int b)
+{
+    return ((r & 0xF8) << 8) | ((g & 0xFC) << 3) | (b >> 3);
+}
+
+static inline void unpack_rgb565_gamma(const uint8_t* src, int pitch, int x, int y, int& r, int& g, int& b)
+{
+    const uint8_t* pixel = src + y * pitch + x * 2;
+    uint16_t color = pixel[0] | (pixel[1] << 8);
+
+    int r5 = (color >> 11) & 0x1F;
+    int g6 = (color >> 5) & 0x3F;
+    int b5 = color & 0x1F;
+
+    r = gamma_r_encode[r5];
+    g = gamma_g_encode[g6];
+    b = gamma_r_encode[b5]; // reuse red table for blue
+}
+
+extern "C"
+void ApplySharpBilinear4x(
+    uint8_t* __restrict dst,
+    int dst_pitch,
+    const uint8_t* __restrict src,
+    int src_width,
+    int src_height,
+    int src_pitch)
+{
+    const int dst_width = src_width * 4;
+    const int dst_height = src_height * 4;
+
+    static bool gamma_ready = false;
+    if (!gamma_ready) {
+        init_gamma_tables();
+        gamma_ready = true;
+    }
+
+    for (int y = 0; y < dst_height; ++y)
+    {
+        float src_yf = y / 4.0f;
+        int sy = static_cast<int>(src_yf);
+        float fy = src_yf - sy;
+        sy = std::clamp(sy, 0, src_height - 2);
+
+        for (int x = 0; x < dst_width; ++x)
+        {
+            float src_xf = x / 4.0f;
+            int sx = static_cast<int>(src_xf);
+            float fx = src_xf - sx;
+            sx = std::clamp(sx, 0, src_width - 2);
+
+            int r0, g0, b0, rx, gx, bx, ry, gy, by;
+
+            unpack_rgb565_gamma(src, src_pitch, sx, sy, r0, g0, b0);
+            unpack_rgb565_gamma(src, src_pitch, sx + 1, sy, rx, gx, bx);
+            unpack_rgb565_gamma(src, src_pitch, sx, sy + 1, ry, gy, by);
+
+            // Blend in gamma space
+            int rh = r0 + static_cast<int>((rx - r0) * fx + 0.5f);
+            int gh = g0 + static_cast<int>((gx - g0) * fx + 0.5f);
+            int bh = b0 + static_cast<int>((bx - b0) * fx + 0.5f);
+
+            int rv = r0 + static_cast<int>((ry - r0) * fy + 0.5f);
+            int gv = g0 + static_cast<int>((gy - g0) * fy + 0.5f);
+            int bv = b0 + static_cast<int>((by - b0) * fy + 0.5f);
+
+            // Average
+            int r = (rh + rv) >> 1;
+            int g = (gh + gv) >> 1;
+            int b = (bh + bv) >> 1;
+
+            // Gamma decode and clamp
+            uint16_t out = build_rgb565_fast(
+                gamma_decode[r],
+                gamma_decode[g],
+                gamma_decode[b]
+            );
+
+            uint8_t* dst_px = dst + y * dst_pitch + x * 2;
+            dst_px[0] = out & 0xFF;
+            dst_px[1] = (out >> 8) & 0xFF;
+        }
+    }
+}
+
+extern "C"
+void filter_sharpbilinear_4x(uint8_t* srcPtr, int srcPitch, uint8_t* dstPtr, int dstPitch,
+    int width, int height)
+{
+    ApplySharpBilinear4x(dstPtr, dstPitch, srcPtr, width, height, srcPitch);
+}


### PR DESCRIPTION
I wrote three interpolation filters that can be easily added to the filter dropdown list by including them in render.cpp and wsnes9x.h. I put the filters into the filter folder.

1. Bicubic 4x: This is a gamma-corrected bicubic upscaler based on Hermite. It's sharper than standard bilinear filtering and causes less smearing.

2. Lanczos 4x: It's a 4x upscaling filter based on the Lanczos algorithm. The output is really sharp. I reduced the bold outlines - a common side effect of blending in RGB-color space - by reducing the influence of true black pixels to blending.   

3. Sharp Bilinear (4x): It's a gamma-corrected bilinear filter that looks better than the built-in bilinear filter as it does not cause overly bold outlines. This is achieved by blending in gamma-space instead of in RGB. The filter is really fast. It uses a smoothstep variation of the standard bilinear algorithm which makes it considerably sharper and less blurry than standard bilinear. 