### PR TITLE
fix build with zlib-ng

### DIFF
--- a/conffile.h
+++ b/conffile.h
@@ -12,6 +12,7 @@
 #include <vector>
 #include <string>
 
+#include "snes9x.h"
 #ifdef UNZIP_SUPPORT
 #  ifdef SYSTEM_ZIP
 #    include <minizip/unzip.h>
@@ -19,7 +20,6 @@
 #    include "unzip/unzip.h"
 #  endif
 #endif
-#include "snes9x.h"
 
 #ifndef MAX
 #  define MAX(a,b)  ((a) > (b)? (a) : (b))

--- a/loadzip.cpp
+++ b/loadzip.cpp
@@ -8,12 +8,12 @@
 
 #include <assert.h>
 #include <ctype.h>
+#include "snes9x.h"
 #ifdef SYSTEM_ZIP
 #include <minizip/unzip.h>
 #else
 #include "unzip/unzip.h"
 #endif
-#include "snes9x.h"
 #include "memmap.h"
 
 

--- a/memmap.cpp
+++ b/memmap.cpp
@@ -10,6 +10,7 @@
 #include <numeric>
 #include <assert.h>
 
+#include "snes9x.h"
 #ifdef UNZIP_SUPPORT
 #  ifdef SYSTEM_ZIP
 #    include <minizip/unzip.h>
@@ -25,7 +26,6 @@
 #include <ctype.h>
 #include <sys/stat.h>
 
-#include "snes9x.h"
 #include "memmap.h"
 #include "apu/apu.h"
 #include "fxemu.h"

--- a/stream.cpp
+++ b/stream.cpp
@@ -7,6 +7,7 @@
 // Abstract the details of reading from zip files versus FILE *'s.
 
 #include <string>
+#include "snes9x.h"
 #ifdef UNZIP_SUPPORT
 #  ifdef SYSTEM_ZIP
 #    include <minizip/unzip.h>
@@ -14,7 +15,6 @@
 #    include "unzip.h"
 #  endif
 #endif
-#include "snes9x.h"
 #include "stream.h"
 
 


### PR DESCRIPTION
`minizip/unzip.h` from minizip-ng dynamically includes `zlib-ng.h` or `zlib.h` depending on what was included prior (https://github.com/zlib-ng/minizip-ng/blob/4.0.10/compat/unzip.h#L22).

That means `snes9x.h` needs to be included first (because it includes `zlib.h`)or the minizip include tries to include `zlib-ng.h` by default.
Because you can't include both (https://github.com/zlib-ng/zlib-ng/blob/2.2.5/zlib.h.in#L34) the build currently fails with zlib-ng.

This probably needs some better formatting (and maybe code comments) but I wanted to see what you guys think first.