### PR TITLE
unix/x11.cpp: Do not call XChangeProperty after failed XInternAtom

### DIFF
--- a/unix/x11.cpp
+++ b/unix/x11.cpp
@@ -755,10 +755,11 @@ xinerama_end:
 							GUI.depth, InputOutput, GUI.visual, CWBackPixel | CWColormap, &attrib);
 
 		/* Try to tell the Window Manager not to decorate this window. */
-		Atom wm_state   = XInternAtom (GUI.display, "_NET_WM_STATE", true );
-		Atom wm_fullscreen = XInternAtom (GUI.display, "_NET_WM_STATE_FULLSCREEN", true );
+		Atom wm_state      = XInternAtom (GUI.display, "_NET_WM_STATE", True);
+		Atom wm_fullscreen = XInternAtom (GUI.display, "_NET_WM_STATE_FULLSCREEN", True);
 
-		XChangeProperty(GUI.display, GUI.window, wm_state, XA_ATOM, 32, PropModeReplace, (unsigned char *)&wm_fullscreen, 1);
+		if (wm_state != None && wm_fullscreen != None)
+			XChangeProperty(GUI.display, GUI.window, wm_state, XA_ATOM, 32, PropModeReplace, (unsigned char *)&wm_fullscreen, 1);
 
 #ifdef USE_XVIDEO
 		if (GUI.use_xvideo)


### PR DESCRIPTION
On machines without a running window manager (bare X11), or WMs that don't support the `_NET_WM_STATE_FULLSCREEN` Atom, `XInternAtom` may return None (i.e. 0), leading to a null pointer exception calling `XChangeProperty` unless it is checked first.

This call is probably unnecessary anyway (in those cases): x11 does not decorate windows with borders or titlebars, so the `XCreateWindow` above has already created a full-screen "borderless" window correctly.