### PR TITLE
macOS: Add input device hotplug support

### DIFF
--- a/macosx/Snes9x/AppDelegate.m
+++ b/macosx/Snes9x/AppDelegate.m
@@ -29,6 +29,7 @@ NSWindowFrameAutosaveName const kCheatsWindowIdentifier = @"s9xCheatsWindow";
 NSWindowFrameAutosaveName const kCheatFinderWindowIdentifier = @"s9xCheatFinderWindow";
 
 @interface AppDelegate () <S9xCheatFinderDelegate>
+@property (nonatomic, strong) id inputDeviceListChangeObserver;
 @end
 
 @implementation AppDelegate
@@ -62,9 +63,16 @@ NSWindowFrameAutosaveName const kCheatFinderWindowIdentifier = @"s9xCheatFinderW
     }];
 
     [self resetWindow];
+
+    self.inputDeviceListChangeObserver = [NSNotificationCenter.defaultCenter addObserverForName:S9xInputDeviceListChangeNotification object:nil queue:NSOperationQueue.mainQueue usingBlock:^(NSNotification *notification)
+    {
+        [self setupJoypadsFromDefaults];
+    }];
 }
 
 - (void)applicationWillTerminate:(NSNotification *)aNotification {
+    [[NSNotificationCenter defaultCenter] removeObserver:self.inputDeviceListChangeObserver];
+
     [self.s9xEngine quit];
 }
 
@@ -144,9 +152,26 @@ NSWindowFrameAutosaveName const kCheatFinderWindowIdentifier = @"s9xCheatFinderW
         [self setButtonCode:buttonCode forKeyCode:self.keys[control].integerValue player:player];
     }
 
-	NSDictionary *joypadPlayerPrefs = [defaults objectForKey:kJoypadPlayerPrefs];
+    [self setupJoypadsFromDefaults];
 
-    for ( S9xJoypad *joypad in [self listJoypads])
+    self.deviceSetting = Gamepads;
+
+    [self importKeySettings];
+    [self importGraphicsSettings];
+    [self applyEmulationSettings];
+
+    self.s9xEngine.cheatsEnabled = [defaults boolForKey:kEnableCheatsPref];
+
+    [defaults synchronize];
+}
+
+- (void)setupJoypadsFromDefaults
+{
+    NSUserDefaults *defaults = NSUserDefaults.standardUserDefaults;
+
+    NSDictionary *joypadPlayerPrefs = [defaults objectForKey:kJoypadPlayerPrefs];
+
+    for (S9xJoypad *joypad in [self listJoypads])
     {
         NSMutableDictionary *joypadPrefs = [[defaults objectForKey:kJoypadInputPrefs] mutableCopy];
 
@@ -196,16 +221,6 @@ NSWindowFrameAutosaveName const kCheatFinderWindowIdentifier = @"s9xCheatFinderW
             }
         }
     }
-
-	self.deviceSetting = Gamepads;
-
-    [self importKeySettings];
-    [self importGraphicsSettings];
-    [self applyEmulationSettings];
-
-    self.s9xEngine.cheatsEnabled = [defaults boolForKey:kEnableCheatsPref];
-
-    [defaults synchronize];
 }
 
 - (void)setButtonCode:(S9xButtonCode)buttonCode forKeyCode:(int16)keyCode player:(int8)player

--- a/macosx/Snes9x/S9xPreferences/S9xControlsPreferencesViewController.m
+++ b/macosx/Snes9x/S9xPreferences/S9xControlsPreferencesViewController.m
@@ -29,6 +29,7 @@
 @property (nonatomic, weak) IBOutlet NSPopUpButton *devicePopUp;
 @property (nonatomic, weak) IBOutlet NSPopUpButton *playerPopUp;
 @property (nonatomic, strong) NSArray *configTextFields;
+@property (nonatomic, strong) id inputDeviceListChangeObserver;
 @end
 
 @implementation S9xControlsPreferencesViewController
@@ -48,15 +49,6 @@
     [super viewDidLoad];
 
 	AppDelegate *appDelegate = (AppDelegate *)NSApp.delegate;
-	NSUInteger joypadIndex = 0;
-	for (S9xJoypad *joypad in [appDelegate listJoypads])
-	{
-		NSMenuItem *item = [NSMenuItem new];
-		item.title = joypad.name;
-		item.tag = joypadIndex++;
-		item.representedObject = joypad;
-		[self.devicePopUp.menu addItem:item];
-	}
 
 	// collect all S9xButtonConfigTextFields within subviews
 	NSMutableArray *configTextFields = [[NSMutableArray alloc] init];
@@ -76,10 +68,50 @@
 		[configTextField addObserver:self forKeyPath:@"keyCode" options:NSKeyValueObservingOptionNew context:NULL];
 		[configTextField addObserver:self forKeyPath:@"joypadInput" options:NSKeyValueObservingOptionNew context:NULL];
 	}
+}
 
-	// select Keyboard as default
-	[self selectDeviceForPlayer:0];
+- (void)viewWillAppear
+{
+	[self refreshDeviceList];
 
+	[super viewWillAppear];
+
+	self.inputDeviceListChangeObserver = [NSNotificationCenter.defaultCenter addObserverForName:S9xInputDeviceListChangeNotification object:nil queue:NSOperationQueue.mainQueue usingBlock:^(NSNotification *notification)
+	{
+		[self refreshDeviceList];
+		[self refresh];
+	}];
+}
+
+- (void)viewWillDisappear
+{
+	[[NSNotificationCenter defaultCenter] removeObserver:self.inputDeviceListChangeObserver];
+
+	[super viewWillDisappear];
+}
+
+- (void)refreshDeviceList
+{
+	AppDelegate *appDelegate = (AppDelegate *)NSApp.delegate;
+
+	// Remove all dynamic devices (keyboard is hard-coded as the first item).
+	while (self.devicePopUp.menu.numberOfItems > 1)
+	{
+		[self.devicePopUp.menu removeItemAtIndex:self.devicePopUp.menu.numberOfItems - 1];
+	}
+
+	NSUInteger joypadIndex = 0;
+	for (S9xJoypad *joypad in [appDelegate listJoypads])
+	{
+		NSMenuItem *item = [NSMenuItem new];
+		item.title = joypad.name;
+		item.tag = joypadIndex++;
+		item.representedObject = joypad;
+		[self.devicePopUp.menu addItem:item];
+	}
+
+	NSInteger playerNum = self.playerPopUp.selectedItem.tag;
+	[self selectDeviceForPlayer:playerNum];
 }
 
 - (void)refresh
@@ -167,7 +199,9 @@
 	AppDelegate *appDelegate = (AppDelegate *)NSApp.delegate;
 	NSString* joypadKey = [[NSUserDefaults.standardUserDefaults objectForKey:kJoypadPlayerPrefs] objectForKey:@(player).stringValue];
 
-	[self.devicePopUp selectItemAtIndex:0];
+	// Select keyboard as default if there is no device configured or as a fallback when the
+	// configured device is not connected.
+	NSInteger deviceItemIndex = 0;
 
 	if (joypadKey != nil)
 	{
@@ -175,23 +209,26 @@
 		uint32 productID = 0;
 		uint32 index = 0;
 
-		if ( [appDelegate getValuesFromString:joypadKey vendorID:&vendorID productID:&productID index:&index])
+		if ([appDelegate getValuesFromString:joypadKey vendorID:&vendorID productID:&productID index:&index])
 		{
 			S9xJoypad *joypad = [S9xJoypad new];
 			joypad.vendorID = vendorID;
 			joypad.productID = productID;
 			joypad.index = index;
 
-			for (NSMenuItem *item in self.devicePopUp.menu.itemArray)
+			NSArray<NSMenuItem *> * items = self.devicePopUp.menu.itemArray;
+			for (NSInteger i = 1; i < items.count; i++)
 			{
-				if ([joypad isEqual:item.representedObject])
+				if ([joypad isEqual:items[i].representedObject])
 				{
-					[self.devicePopUp selectItem:item];
+					deviceItemIndex = i;
 					break;
 				}
 			}
 		}
 	}
+
+	[self.devicePopUp selectItemAtIndex:deviceItemIndex];
 }
 
 - (BOOL)handleInput:(S9xJoypadInput *)input fromJoypad:(S9xJoypad *)joypad

--- a/macosx/mac-joypad.h
+++ b/macosx/mac-joypad.h
@@ -120,8 +120,13 @@ namespace std {
     };
 }
 
+typedef void (*DeviceListChangeCallback)(void * _Nullable context);
+
 void SetUpHID (void);
 void ReleaseHID (void);
+
+void RegisterDeviceListChangeCallback(DeviceListChangeCallback _Nullable callback, void * _Nullable context);
+void UnregisterDeviceListChangeCallback(DeviceListChangeCallback _Nullable callback);
 
 std::unordered_set<struct JoypadDevice> ListJoypads (void);
 std::string NameForDevice(struct JoypadDevice device);

--- a/macosx/mac-joypad.mm
+++ b/macosx/mac-joypad.mm
@@ -45,6 +45,7 @@ std::unordered_map<uint32, int8> deviceIndexByPort;
 std::unordered_map<JoypadCookie, JoypadCookieInfo> infoByCookie;
 std::unordered_map<JoypadInput, S9xButtonCode> buttonCodeByJoypadInput;
 std::unordered_map<JoypadDevice, std::string> namesByDevice;
+std::vector<std::pair<DeviceListChangeCallback, void *>> deviceListChangeCallbacks;
 
 @interface NSData (S9xHexString)
 +(id)s9x_dataWithHexString:(NSString *)hex;
@@ -518,8 +519,14 @@ void SetDefaultButtonCodeForJoypadControl(struct JoypadInput &input, S9xButtonCo
     SetButtonCodeForJoypadControl(input.cookie.device.vendorID, input.cookie.device.productID, input.cookie.device.index, input.cookie.cookie, input.value, buttonCode, false, NULL);
 }
 
-void AddDevice (IOHIDDeviceRef device)
+void AddDevice(IOHIDDeviceRef device)
 {
+    uint32_t port = ((NSNumber *)IOHIDDeviceGetProperty(device, CFSTR(kIOHIDLocationIDKey))).unsignedIntValue;
+    if (deviceIndexByPort.find(port) != deviceIndexByPort.end())
+    {
+        return; // There's already something at that location.
+    }
+
     NSNumber *vendor = (NSNumber *)IOHIDDeviceGetProperty(device, CFSTR(kIOHIDVendorIDKey));
     NSNumber *product = (NSNumber *)IOHIDDeviceGetProperty(device, CFSTR(kIOHIDProductIDKey));
     NSString *name = (NSString *)IOHIDDeviceGetProperty(device, CFSTR(kIOHIDProductKey));
@@ -554,7 +561,6 @@ void AddDevice (IOHIDDeviceRef device)
     }
 
     namesByDevice[deviceStruct] = s;
-    uint32_t port = ((NSNumber *)IOHIDDeviceGetProperty(device, CFSTR(kIOHIDLocationIDKey))).unsignedIntValue;
     deviceIndexByPort[port] = deviceStruct.index;
 
     CFMutableDictionaryRef properties = NULL;
@@ -682,6 +688,54 @@ void AddDevice (IOHIDDeviceRef device)
     CFRelease(properties);
 }
 
+void RemoveDevice(IOHIDDeviceRef device)
+{
+    uint32 port = ((NSNumber *)IOHIDDeviceGetProperty(device, CFSTR(kIOHIDLocationIDKey))).unsignedIntValue;
+
+    auto deviceIndexByPortIterator = deviceIndexByPort.find(port);
+    if (deviceIndexByPortIterator == deviceIndexByPort.end())
+    {
+        return; // unknown device
+    }
+
+    NSNumber *vendor = (NSNumber *)IOHIDDeviceGetProperty(device, CFSTR(kIOHIDVendorIDKey));
+    NSNumber *product = (NSNumber *)IOHIDDeviceGetProperty(device, CFSTR(kIOHIDProductIDKey));
+
+    struct JoypadDevice deviceStruct;
+    deviceStruct.vendorID = vendor.unsignedIntValue;
+    deviceStruct.productID = product.unsignedIntValue;
+    deviceStruct.index = deviceIndexByPortIterator->second;
+
+    allDevices.erase(deviceStruct);
+    deviceIndexByPort.erase(deviceIndexByPortIterator);
+}
+
+void TriggerDeviceListChange()
+{
+    for (auto it = deviceListChangeCallbacks.begin(); it != deviceListChangeCallbacks.end(); ++it)
+    {
+        (*it->first)(it->second);
+    }
+}
+
+void gamepadMatchingAction(void *inContext, IOReturn inResult, void *inSender, IOHIDDeviceRef device)
+{
+    pthread_mutex_lock(&keyLock);
+    AddDevice(device);
+    pthread_mutex_unlock(&keyLock);
+
+    TriggerDeviceListChange();
+}
+
+void gamepadRemovalAction(void *inContext, IOReturn inResult, void *inSender, IOHIDDeviceRef device)
+{
+    pthread_mutex_lock(&keyLock);
+    RemoveDevice(device);
+    pthread_mutex_unlock(&keyLock);
+
+    TriggerDeviceListChange();
+}
+
 void ClearJoypad(uint32 vendorID, uint32 productID, uint32 index)
 {
     struct JoypadDevice device;
@@ -728,6 +782,9 @@ void SetUpHID (void)
 
     if (hidManager != NULL && IOHIDManagerOpen(hidManager, kIOHIDOptionsTypeNone) == kIOReturnSuccess)
     {
+        IOHIDManagerRegisterDeviceMatchingCallback(hidManager, gamepadMatchingAction, NULL);
+        IOHIDManagerRegisterDeviceRemovalCallback(hidManager, gamepadRemovalAction, NULL);
+
         IOHIDManagerRegisterInputValueCallback(hidManager, gamepadAction, NULL);
         IOHIDManagerScheduleWithRunLoop(hidManager, CFRunLoopGetMain(), kCFRunLoopDefaultMode);
 
@@ -836,6 +893,19 @@ void ReleaseHID (void)
     if ( hidManager != NULL)
     {
         IOHIDManagerClose(hidManager, kIOHIDOptionsTypeNone);
+
+        pthread_mutex_lock(&keyLock);
+        allDevices.clear();
+        defaultAxes.clear();
+        defaultButtons.clear();
+        defaultHatValues.clear();
+        playerNumByDevice.clear();
+        deviceIndexByPort.clear();
+        infoByCookie.clear();
+        buttonCodeByJoypadInput.clear();
+        namesByDevice.clear();
+        deviceListChangeCallbacks.clear();
+        pthread_mutex_unlock(&keyLock);
     }
 }
 
@@ -1105,4 +1175,44 @@ std::string LabelForInput(uint32 vendorID, uint32 productID, uint32 cookie, int3
     }
 
     return std::to_string(cookie);
+}
+
+void RegisterDeviceListChangeCallback(DeviceListChangeCallback _Nullable callback, void * _Nullable context)
+{
+    pthread_mutex_lock(&keyLock);
+
+    auto it = deviceListChangeCallbacks.begin();
+    for (; it != deviceListChangeCallbacks.end(); ++it)
+    {
+        if (it->first == callback)
+        {
+            break;
+        }
+    }
+    if (it == deviceListChangeCallbacks.end())
+    {
+        deviceListChangeCallbacks.push_back(std::pair<DeviceListChangeCallback, void *>(callback, context));
+    }
+    else
+    {
+        it->second = context;
+    }
+
+    pthread_mutex_unlock(&keyLock);
+}
+
+void UnregisterDeviceListChangeCallback(DeviceListChangeCallback _Nullable callback)
+{
+    pthread_mutex_lock(&keyLock);
+
+    for (auto it = deviceListChangeCallbacks.begin(); it != deviceListChangeCallbacks.end(); ++it)
+    {
+        if (it->first == callback)
+        {
+            deviceListChangeCallbacks.erase(it);
+            break;
+        }
+    }
+
+    pthread_mutex_unlock(&keyLock);
 }

--- a/macosx/mac-os.h
+++ b/macosx/mac-os.h
@@ -89,6 +89,8 @@ typedef struct
 #define kMacWindowHeight	(SNES_HEIGHT_EXTENDED)
 #define MAC_MAX_CHEATS      150
 
+extern NSNotificationName const S9xInputDeviceListChangeNotification;
+
 extern volatile bool8	running, s9xthreadrunning;
 extern volatile bool8	eventQueued, windowExtend;
 extern uint32			controlPad[MAC_MAX_PLAYERS];

--- a/macosx/mac-os.mm
+++ b/macosx/mac-os.mm
@@ -64,6 +64,8 @@
 
 #define	kRecentMenu_MAX		20
 
+NSNotificationName const S9xInputDeviceListChangeNotification = @"S9xInputDeviceListChangeNotification";
+
 volatile bool8		running             = false;
 volatile bool8		s9xthreadrunning    = false;
 
@@ -2500,6 +2502,11 @@ static void ChangeAutofireSettings (int player, int btn)
     S9xSetInfoString(msg);
 }
 
+static void PostDeviceListChange(void *)
+{
+	[[NSNotificationCenter defaultCenter] postNotificationName:S9xInputDeviceListChangeNotification object:nil];
+}
+
 static void ChangeTurboRate (int d)
 {
     static char    msg[64];
@@ -2566,6 +2573,8 @@ static void Initialize (void)
 	InitMacSound();
 	SetUpHID();
 
+	RegisterDeviceListChangeCallback(PostDeviceListChange, NULL);
+
 	autofire = (autofireRec[0].buttonMask || autofireRec[1].buttonMask) ? true : false;
 	for (int a = 0; a < MAC_MAX_PLAYERS; a++)
 		for (int b = 0; b < 12; b++)
@@ -2592,6 +2601,8 @@ static void Initialize (void)
 static void Deinitialize (void)
 {
 	deviceSetting = deviceSettingMaster;
+
+	UnregisterDeviceListChangeCallback(PostDeviceListChange);
 
 	ReleaseHID();
 	DeinitGraphics();


### PR DESCRIPTION
Adds support for dynamically swapping game controllers during runtime. Mappings and player assignments are applied from the defaults when a device is plugged in. Controller settings window is updated when open during swapping. Uses `NSNotificationCenter` to propagate the event.