### PR TITLE
Adding StartupWMClass

### DIFF
--- a/gtk/data/snes9x-gtk.desktop
+++ b/gtk/data/snes9x-gtk.desktop
@@ -8,3 +8,4 @@ Categories=Game;Emulator;
 MimeType=application/vnd.nintendo.snes.rom;application/x-snes-rom;
 Exec=snes9x-gtk %F
 Icon=snes9x
+StartupWMClass=snes9x-gtk


### PR DESCRIPTION
I noticed that in KDE the icon used in the bar where the apps are located is the Wayland icon instead of the .desktop icon; this pull request is to fix that.