### PR TITLE
interpret cheat names as utf-8 instead of ascii in debugger

### DIFF
--- a/win32/SCheatGroup.natvis
+++ b/win32/SCheatGroup.natvis
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?> 
+<AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
+	<Type Name="SCheatGroup">
+		<DisplayString>{{ name={name,s8}, enabled={enabled},cheat={cheat} }}</DisplayString>
+	</Type>
+</AutoVisualizer>

--- a/win32/snes9xw.vcxproj
+++ b/win32/snes9xw.vcxproj
@@ -715,6 +715,9 @@
       <Project>{99e9817a-4605-44af-8433-7048f0ec1859}</Project>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Natvis Include="SCheatGroup.natvis" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/win32/snes9xw.vcxproj.filters
+++ b/win32/snes9xw.vcxproj.filters
@@ -1012,4 +1012,9 @@
     </CustomBuild>
     <CustomBuild Include="snes9x.cfg" />
   </ItemGroup>
+  <ItemGroup>
+    <Natvis Include="SCheatGroup.natvis">
+      <Filter>GUI</Filter>
+    </Natvis>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
By default, visual studio debugger displays std::string as ascii. This will misinterprete multi‑byte UTF‑8 sequences strings such as SCheatGroup.name.

SCheatGroup.natvis changes the name decoding to utf-8 in the debugger.