### PR TITLE
win32: fix save-slot corruption from SelectSave hotkey on bank > 0

### DIFF
--- a/win32/wconfig.cpp
+++ b/win32/wconfig.cpp
@@ -277,6 +277,9 @@ const TCHAR*	WinParseCommandLineAndLoadConfigFile (TCHAR *line)
 
 	S9xLoadConfigFiles(parameters, count);
 
+	if (GUI.CurrentSaveSlot < 0 || GUI.CurrentSaveSlot > LAST_SAVE_SLOT_IN_BANK)
+		GUI.CurrentSaveSlot = 0;
+
 	ReleaseMutex(configMutex);
 	CloseHandle(configMutex);
 

--- a/win32/wsnes9x.cpp
+++ b/win32/wsnes9x.cpp
@@ -1332,7 +1332,7 @@ int HandleKeyMessage(WPARAM wParam, LPARAM lParam)
 		{
 			if(wParam == CustomKeys.SelectSave[i].key && modifiers == CustomKeys.SelectSave[i].modifiers)
 			{
-				GUI.CurrentSaveSlot = GUI.CurrentSaveBank * SAVE_SLOTS_PER_BANK + i;
+				GUI.CurrentSaveSlot = i;
 
 				ShowStatusSlotInfo();
 


### PR DESCRIPTION
The "Select save slot N" hotkey stored an absolute slot index (bank * SAVE_SLOTS_PER_BANK + i) into GUI.CurrentSaveSlot, but every other call site treats CurrentSaveSlot as the in-bank slot (0..9) and re-applies the bank multiplier when computing the filename. After pressing SelectSave on bank >= 1, CurrentSaveSlot was left >= 10, so the next save/load went to slot bank*10 + (bank*10 + i) and the status bar's "save slot 0NN" no longer matched the file actually written (e.g. slot 5 in bank 1 produced .025 instead of .015).

Store just `i` and clamp the value on config load so existing corrupted snes9x.conf entries self-heal.

Fixes #1052.