### PR TITLE
win32: Fix crash/assert opening the Custom ROM dialog a second time

### DIFF
--- a/win32/wsnes9x.cpp
+++ b/win32/wsnes9x.cpp
@@ -6416,10 +6416,10 @@ INT_PTR CALLBACK DlgOpenROMProc(HWND hDlg, UINT msg, WPARAM wParam, LPARAM lPara
 						lstrcpy(filename,_tFromChar(Memory.ROMFilename.c_str()));
 						tmp = filename;
 						while(tmp2=_tcsstr(tmp, TEXT("\\")))
-							tmp=tmp2+sizeof(TCHAR);
+							tmp=tmp2+1;
 
 						lvfi.flags=LVFI_STRING;
-						lvfi.psz=tmp2;
+						lvfi.psz=tmp;
 
 						int idx=ListView_FindItem(romList, -1, &lvfi);
 						ListView_SetSelectionMark(romList, idx);


### PR DESCRIPTION
Originally posted by @Nekokabu in [SuperSnes9x ](https://github.com/shanytc/snes9x/issues/41#issuecomment-4708391865) issues page:

## Problem

With **Settings → Custom ROM Open Dialog** enabled, opening a ROM via *File → Load Game* (or a recent ROM) works the first time, but opening the dialog a **second time** crashes — a debug assertion `rhs != nullptr` in `minkernel\crts\ucrt\src\appcrt\string\wcsnicmp.cpp`, or an access violation in release builds.

The crash surfaces inside `DlgOpenROMProc()`'s `LVN_ODFINDITEM` handler, where `_tcsnicmp(curr->fname, searchstr, lstrlen(searchstr))` is called with `searchstr == NULL`.

## Root cause

`IDC_ROMLIST` is an owner-data (virtual) list view (`LVS_OWNERDATA`), so a `ListView_FindItem` call is bounced back to us as `LVN_ODFINDITEM` to perform the search ourselves.

The ROM pre-selection block in `DlgOpenROMProc()` builds the search string wrong:

```c
tmp = filename;
while(tmp2=_tcsstr(tmp, TEXT("\\")))   // walk to the last '\'
    tmp=tmp2+sizeof(TCHAR);
lvfi.flags=LVFI_STRING;
lvfi.psz=tmp2;                          // BUG: tmp2 is the loop terminator -> always NULL
int idx=ListView_FindItem(romList, -1, &lvfi);
```

The loop exits precisely when `_tcsstr` returns `NULL`, so on exit `tmp2` is **always NULL**. Assigning `lvfi.psz = tmp2` therefore passes a NULL search string (with `LVFI_STRING` set) into `ListView_FindItem`, which re-enters our `LVN_ODFINDITEM` handler and feeds the NULL to `_tcsnicmp` → assert/crash. The intended pointer is `tmp`, which points at the basename.

It only triggers on the *second* open because the block is gated on `Memory.ROMFilename[0] != '\0'`: on the first open of a session no ROM is loaded yet, so the block is skipped. After a ROM is loaded, the second open runs it and crashes.

There is also a secondary defect on the line above: `tmp2` is a `TCHAR*`, so `tmp2 + sizeof(TCHAR)` over-advances by an extra character in Unicode builds (it should be `tmp2 + 1`). This left the basename pointer one character off even when it wasn't NULL.

## Fix

```c
while(tmp2=_tcsstr(tmp, TEXT("\\")))
    tmp=tmp2+1;          // was tmp2+sizeof(TCHAR)
lvfi.flags=LVFI_STRING;
lvfi.psz=tmp;            // was tmp2 (always NULL)
```

This both eliminates the crash and makes the "highlight the currently-loaded ROM in the list" pre-selection actually work (it previously always returned -1).