### PR TITLE
win32: recreate render window on display reset to fix Vulkan→D3D/DDraw switching

### DIFF
--- a/win32/CDirect3D.cpp
+++ b/win32/CDirect3D.cpp
@@ -58,6 +58,7 @@ CDirect3D::CDirect3D()
 	shaderTimeStart = 0;
 	shaderTimeElapsed = 0;
 	frameCount = 0;
+	hWnd = NULL;
 	cgContext = NULL;
 	cgAvailable = false;
 	cgShader = NULL;
@@ -91,6 +92,8 @@ bool CDirect3D::Initialize(HWND hWnd)
 		return false;
 	}
 
+	this->hWnd = hWnd;
+
 	memset(&dPresentParams, 0, sizeof(dPresentParams));
 	dPresentParams.hDeviceWindow = hWnd;
     dPresentParams.Windowed = true;
@@ -100,7 +103,7 @@ bool CDirect3D::Initialize(HWND hWnd)
 
 	HRESULT hr = pD3D->CreateDevice(D3DADAPTER_DEFAULT,
                       D3DDEVTYPE_HAL,
-                      hWnd,
+                      GUI.hWnd,
                       D3DCREATE_MIXED_VERTEXPROCESSING,
 					  &dPresentParams,
                       &pDevice);
@@ -200,6 +203,7 @@ void CDirect3D::DeInitialize()
 	}
 
 	init_done = false;
+	hWnd = NULL;
 	afterRenderWidth = 0;
 	afterRenderHeight = 0;
 	quadTextureSize = 0;
@@ -289,7 +293,7 @@ void CDirect3D::Render(SSurface Src)
 			case D3DERR_DEVICELOST:		//do no rendering until device is restored
 				return;
 			case D3DERR_DEVICENOTRESET: //we can reset now
-                if(!IsIconic(dPresentParams.hDeviceWindow))
+                if(!IsIconic(GUI.hWnd))
 				    ResetDevice();
 				return;
 			default:
@@ -570,6 +574,7 @@ bool CDirect3D::ResetDevice()
 	}
 
 	//zero or unknown values result in the current window size/display settings
+	dPresentParams.hDeviceWindow = hWnd;
 	dPresentParams.BackBufferWidth = 0;
 	dPresentParams.BackBufferHeight = 0;
 	dPresentParams.BackBufferCount = GUI.DoubleBuffered?2:1;
@@ -580,6 +585,7 @@ bool CDirect3D::ResetDevice()
 	dPresentParams.Flags = D3DPRESENTFLAG_LOCKABLE_BACKBUFFER;
 
 	if(fullscreen) {
+		dPresentParams.hDeviceWindow = GUI.hWnd;
 		dPresentParams.BackBufferWidth = GUI.FullscreenMode.width;
 		dPresentParams.BackBufferHeight = GUI.FullscreenMode.height;
 		dPresentParams.BackBufferCount = GUI.DoubleBuffered?2:1;

--- a/win32/CDirect3D.h
+++ b/win32/CDirect3D.h
@@ -37,6 +37,7 @@ class CDirect3D: public IS9xDisplayOutput
 {
 private:
 	bool                  init_done;					//has initialize been called?
+	HWND                  hWnd;							//the render window
 	LPDIRECT3D9           pD3D;
 	LPDIRECT3DDEVICE9     pDevice;
 	LPDIRECT3DTEXTURE9    drawSurface;					//the texture used for all drawing operations

--- a/win32/win32_display.cpp
+++ b/win32/win32_display.cpp
@@ -12,6 +12,7 @@
 #include "../snes9x.h"
 #include "../ppu.h"
 #include "../font.h"
+#include <shellapi.h>
 #include "wsnes9x.h"
 #include "win32_display.h"
 #include "CDirect3D.h"
@@ -35,6 +36,8 @@ COpenGL OpenGL;
 CVulkan VulkanDriver;
 SSurface Src = {0};
 extern BYTE *ScreenBufferBlend;
+
+static const TCHAR RENDER_WINDOW_CLASS[] = TEXT("Snes9x: Render Window");
 
 typedef HRESULT (*DWMFLUSHPROC)();
 typedef HRESULT (*DWMISCOMPOSITIONENABLEDPROC)(BOOL *);
@@ -98,6 +101,71 @@ void WinChangeWindowSize(unsigned int newWidth, unsigned int newHeight)
 	S9xDisplayOutput->ChangeRenderSize(newWidth,newHeight);
 }
 
+static LRESULT CALLBACK RenderWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
+{
+	switch (uMsg)
+	{
+		case WM_NCHITTEST:
+			return HTTRANSPARENT;
+		case WM_DROPFILES:
+			return SendMessage(GUI.hWnd, uMsg, wParam, lParam);
+		case WM_PAINT:
+		{
+			PAINTSTRUCT ps;
+			BeginPaint(hWnd, &ps);
+			EndPaint(hWnd, &ps);
+			WinRefreshDisplay();
+			return 0;
+		}
+	}
+	return DefWindowProc(hWnd, uMsg, wParam, lParam);
+}
+
+/*  WinRecreateRenderWindow
+(re)creates the child window the display drivers present into.
+Windows stops composing blt-model presents (windowed D3D9/DirectDraw/GDI)
+to a window once a flip-model swapchain (Vulkan) has presented to it,
+so the render window is recreated on every display reset.
+*/
+void WinRecreateRenderWindow(void)
+{
+	static bool classRegistered = false;
+
+	if (GUI.hWndRender)
+	{
+		DestroyWindow(GUI.hWndRender);
+		GUI.hWndRender = NULL;
+	}
+
+	if (!GUI.hWnd)
+		return;
+
+	if (!classRegistered)
+	{
+		WNDCLASSEX wc;
+		memset(&wc, 0, sizeof(wc));
+		wc.cbSize = sizeof(wc);
+		wc.style = CS_OWNDC;
+		wc.lpfnWndProc = RenderWndProc;
+		wc.hInstance = GUI.hInstance;
+		wc.hbrBackground = (HBRUSH)GetStockObject(BLACK_BRUSH);
+		wc.lpszClassName = RENDER_WINDOW_CLASS;
+		if (!RegisterClassEx(&wc))
+			return;
+		classRegistered = true;
+	}
+
+	RECT rect;
+	GetClientRect(GUI.hWnd, &rect);
+	GUI.hWndRender = CreateWindowEx(0, RENDER_WINDOW_CLASS, NULL,
+		WS_CHILD | WS_VISIBLE | WS_CLIPSIBLINGS,
+		0, 0, rect.right, rect.bottom,
+		GUI.hWnd, NULL, GUI.hInstance, NULL);
+
+	if (GUI.hWndRender)
+		DragAcceptFiles(GUI.hWndRender, TRUE);
+}
+
 /*  WinDisplayReset
 initializes the currently selected display output and
 reinitializes the core graphics rendering
@@ -110,6 +178,8 @@ bool WinDisplayReset(void)
 	static bool VulkanUsed = false;
 	static bool OpenGLUsed = false;
 	S9xDisplayOutput->DeInitialize();
+	WinRecreateRenderWindow();
+	HWND hWndRender = GUI.hWndRender ? GUI.hWndRender : GUI.hWnd;
 
 	switch(GUI.outputMethod) {
 		default:
@@ -139,7 +209,7 @@ bool WinDisplayReset(void)
 			break;
 	}
 
-	bool initialized = S9xDisplayOutput->Initialize(GUI.hWnd);
+	bool initialized = S9xDisplayOutput->Initialize(hWndRender);
 
 	if (!initialized) {
 		S9xDisplayOutput->DeInitialize();
@@ -163,7 +233,7 @@ bool WinDisplayReset(void)
 		_stprintf(msg, TEXT("Couldn't load selected driver: %s. Trying %s."), oldDriverName, newDriverName);
 		MessageBox(GUI.hWnd, msg, TEXT("Snes9x Display Driver"), MB_OK | MB_ICONERROR);
 
-		initialized = S9xDisplayOutput->Initialize(GUI.hWnd);
+		initialized = S9xDisplayOutput->Initialize(hWndRender);
 	}
 
 	if (initialized) {
@@ -553,14 +623,14 @@ void ToggleFullScreen ()
 		if(GUI.EmulatedFullscreen) {
 			if(GetMenu(GUI.hWnd)!=NULL)
 				SetMenu(GUI.hWnd,NULL);
-			SetWindowLongPtr (GUI.hWnd, GWL_STYLE, WS_POPUP|WS_VISIBLE);
+			SetWindowLongPtr (GUI.hWnd, GWL_STYLE, WS_POPUP|WS_VISIBLE|WS_CLIPCHILDREN|WS_CLIPSIBLINGS);
 			hm = MonitorFromWindow(GUI.hWnd,MONITOR_DEFAULTTONEAREST);
 			mi.cbSize = sizeof(mi);
 			GetMonitorInfo(hm,&mi);
 			SetWindowPos (GUI.hWnd, HWND_TOP, mi.rcMonitor.left, mi.rcMonitor.top, mi.rcMonitor.right - mi.rcMonitor.left, mi.rcMonitor.bottom - mi.rcMonitor.top, SWP_DRAWFRAME|SWP_FRAMECHANGED);
 		} else {
 			SetWindowLongPtr( GUI.hWnd, GWL_STYLE, WS_POPUPWINDOW|WS_CAPTION|
-                   WS_THICKFRAME|WS_VISIBLE|WS_MINIMIZEBOX|WS_MAXIMIZEBOX);
+                   WS_THICKFRAME|WS_VISIBLE|WS_MINIMIZEBOX|WS_MAXIMIZEBOX|WS_CLIPCHILDREN|WS_CLIPSIBLINGS);
 			SetMenu(GUI.hWnd,GUI.hMenu);
 			SetWindowPos (GUI.hWnd, HWND_NOTOPMOST, 0, 0, 0, 0, SWP_NOMOVE|SWP_NOSIZE|SWP_DRAWFRAME|SWP_FRAMECHANGED);
 			RestoreMainWinPos();
@@ -579,7 +649,7 @@ void ToggleFullScreen ()
 		}
 		if(!GUI.FullScreen) {
 			SetWindowLongPtr(GUI.hWnd, GWL_STYLE, WS_POPUPWINDOW|WS_CAPTION|
-                   WS_THICKFRAME|WS_VISIBLE|WS_MINIMIZEBOX|WS_MAXIMIZEBOX);
+                   WS_THICKFRAME|WS_VISIBLE|WS_MINIMIZEBOX|WS_MAXIMIZEBOX|WS_CLIPCHILDREN|WS_CLIPSIBLINGS);
             SetWindowLongPtr(GUI.hWnd, GWL_EXSTYLE, WS_EX_ACCEPTFILES | WS_EX_APPWINDOW);
 			SetMenu(GUI.hWnd,GUI.hMenu);
 			S9xDisplayOutput->SetFullscreen(false);

--- a/win32/win32_display.h
+++ b/win32/win32_display.h
@@ -28,6 +28,7 @@ void RestoreGUIDisplay ();
 void RestoreSNESDisplay ();
 void WinChangeWindowSize(unsigned int newWidth, unsigned int newHeight);
 bool WinDisplayReset(void);
+void WinRecreateRenderWindow(void);
 void WinDisplayApplyChanges();
 RECT CalculateDisplayRect(unsigned int sourceWidth,unsigned int sourceHeight,
 						  unsigned int displayWidth,unsigned int displayHeight);

--- a/win32/wsnes9x.cpp
+++ b/win32/wsnes9x.cpp
@@ -2460,6 +2460,8 @@ LRESULT CALLBACK WinProc(
 		{
 			S9xSetPause(PAUSE_INACTIVE_WINDOW);
 		}
+		if (GUI.hWndRender)
+			MoveWindow(GUI.hWndRender, 0, 0, LOWORD(lParam), HIWORD(lParam), FALSE);
 		WinChangeWindowSize(LOWORD(lParam),HIWORD(lParam));
 		break;
 	case WM_MOVE:

--- a/win32/wsnes9x.h
+++ b/win32/wsnes9x.h
@@ -148,6 +148,7 @@ struct sCustomRomDlgSettings {
 
 struct sGUI {
     HWND hWnd;
+    HWND hWndRender;
     HMENU hMenu;
     HINSTANCE hInstance;
 


### PR DESCRIPTION
## Problem

On the Windows port, switching the output method from Vulkan back to Direct3D or DirectDraw freezes the game display (the last Vulkan frame stays on screen) while emulation and audio keep running; only restarting the application recovers. Reported and reproduced on NVIDIA hardware in shanytc/snes9x#152 (repro: load a game, switch Display Settings → Output Method to Vulkan, then back to Direct3D or DirectDraw).

This is documented Windows behavior rather than a driver teardown bug: once a **flip-model swapchain** has presented to an HWND, DWM permanently stops composing **blt-model presents** (windowed D3D9, DirectDraw, GDI) to that window — the HWND has to be destroyed and recreated. Current NVIDIA/AMD/Intel drivers route windowed Vulkan presentation through DXGI flip model, so after Vulkan presents once to the main window, subsequent windowed D3D9/DirectDraw presents succeed but are never composed. (That's also why the bug doesn't reproduce on machines where Vulkan never actually presents.)

## Fix

All display drivers now present into a dedicated borderless child window covering the client area, and `WinDisplayReset()` destroys and recreates it on every reset, so each renderer switch gets a fresh, untainted HWND — the same architecture other multi-API frontends use.

- **win32_display.cpp** — new `WinRecreateRenderWindow()` plus a minimal child wndproc: hit-test transparent (`WM_NCHITTEST` → `HTTRANSPARENT`, so mouse/superscope input still reaches the main window), forwards `WM_DROPFILES` to the main window, repaints via `WinRefreshDisplay()`. Also restores `WS_CLIPCHILDREN|WS_CLIPSIBLINGS` in the `ToggleFullScreen` style switches that previously dropped them.
- **wsnes9x.cpp** — the child tracks the client area on `WM_SIZE` before the driver's `ChangeRenderSize` runs.
- **CDirect3D.cpp/.h** — the device *focus* window stays the top-level `GUI.hWnd` (a D3D9 requirement for exclusive fullscreen); the *device* window is the child while windowed and swaps to the top-level window on the fullscreen `Reset`; the minimize check now tests `IsIconic(GUI.hWnd)` since a child window is never iconic.
- **CDirectDraw** needs no changes — the clipper receives the child through `Initialize()`, and the blt rects computed from `GUI.hWnd` are identical because the child exactly covers the client area.

A side benefit: OpenGL's once-per-window `SetPixelFormat` limitation now always hits a virgin window (see the existing workaround comment in `COpenGL::Initialize`). The existing OpenGL⇄Vulkan restart guards in `WinDisplayReset` are left untouched, though they may now be removable since every switch gets a new HWND.

## Testing

- Vulkan → Direct3D and Vulkan → DirectDraw while a game runs: video keeps updating (previously froze until app restart).
- Repeated back-and-forth switches between all four output methods, window resizing, borderless and exclusive fullscreen per renderer, ROM drag-and-drop onto the window, on-screen messages on each renderer.