### PR TITLE
Reject ZIP parts that exceed remaining ROM capacity

### DIFF
--- a/loadzip.cpp
+++ b/loadzip.cpp
@@ -17,7 +17,8 @@
 #include "memmap.h"
 
 
-bool8 LoadZip (const char *zipname, uint32 *TotalFileSize, uint8 *buffer)
+bool8 LoadZip (const char *zipname, uint32 *TotalFileSize, uint8 *buffer,
+               uint32 buffer_size)
 {
 	*TotalFileSize = 0;
 
@@ -101,6 +102,13 @@ bool8 LoadZip (const char *zipname, uint32 *TotalFileSize, uint8 *buffer)
 		assert(info.uncompressed_size <= CMemory::MAX_ROM_SIZE + 512);
 
 		uint32 FileSize = info.uncompressed_size;
+		uint32 used = ptr - buffer;
+		if (used > buffer_size || FileSize > buffer_size - used)
+		{
+			unzCloseCurrentFile(file);
+			unzClose(file);
+			return (FALSE);
+		}
 		int	l = unzReadCurrentFile(file, ptr, FileSize);
 
 		if (unzCloseCurrentFile(file) == UNZ_CRCERROR)
@@ -121,13 +129,13 @@ bool8 LoadZip (const char *zipname, uint32 *TotalFileSize, uint8 *buffer)
 
 		int	len;
 
-		if (ptr - Memory.ROM < CMemory::MAX_ROM_SIZE + 512 && (isdigit(ext[0]) && ext[1] == 0 && ext[0] < '9'))
+		if (ptr - buffer < buffer_size && (isdigit(ext[0]) && ext[1] == 0 && ext[0] < '9'))
 		{
 			more = TRUE;
 			ext[0]++;
 		}
 		else
-		if (ptr - Memory.ROM < CMemory::MAX_ROM_SIZE + 512)
+		if (ptr - buffer < buffer_size)
 		{
 			if (ext == tmp)
 				len = strlen(filename);

--- a/memmap.cpp
+++ b/memmap.cpp
@@ -1237,7 +1237,7 @@ uint32 CMemory::FileLoader (uint8 *buffer, const char *filename, uint32 maxsize)
 		case FILE_ZIP:
 		{
 		#ifdef UNZIP_SUPPORT
-			if (!LoadZip(filename, &totalSize, buffer))
+			if (!LoadZip(filename, &totalSize, buffer, maxsize + 0x200))
 			{
 			 	S9xMessage(S9X_ERROR, S9X_ROM_INFO, "Invalid Zip archive.");
 				return (0);

--- a/memmap.h
+++ b/memmap.h
@@ -208,7 +208,7 @@ inline bool S9xInterlaceField()
 }
 
 void S9xAutoSaveSRAM (void);
-bool8 LoadZip(const char *, uint32 *, uint8 *);
+bool8 LoadZip(const char *, uint32 *, uint8 *, uint32);
 
 enum s9xwrap_t
 {


### PR DESCRIPTION
Multipart ZIP ROMs are checked one file at a time, so a `.1` file followed by a `.2` file can write beyond the ROM buffer. This corrupts emulator memory when opening a crafted archive.

Pass the destination capacity into `LoadZip` and reject any member that exceeds the remaining space before decompression.

Tested with an AddressSanitizer reproducer containing two 12 MiB parts. The fixed loader rejects the archive without a sanitizer error.