### PR TITLE
Win32: fix WaveOut sound-sync pacing locking ~20% below real time

### DIFF
--- a/win32/CWaveOut.cpp
+++ b/win32/CWaveOut.cpp
@@ -20,6 +20,10 @@ CWaveOut::CWaveOut(void)
 {
     hWaveOut = NULL;
     initDone = false;
+    bufferCount = 0;
+    submittedBytes = 0;
+    playedBytesAccum = 0;
+    lastPosBytes = 0;
 }
 
 CWaveOut::~CWaveOut(void)
@@ -59,6 +63,13 @@ bool CWaveOut::SetupSound()
 	int device_index = FindDeviceIndex(GUI.AudioDevice) - 1;
 
     waveOutOpen(&hWaveOut, device_index, &wfx, (DWORD_PTR)WaveCallback, (DWORD_PTR)this, CALLBACK_FUNCTION);
+
+    // Fresh device: position restarts at 0 and nothing is in flight, so
+    // reset the accounting instead of trusting waveOutReset's callbacks.
+    bufferCount = 0;
+    submittedBytes = 0;
+    playedBytesAccum = 0;
+    lastPosBytes = 0;
 
     UINT32 blockTime = GUI.SoundBufferSize / blockCount;
     singleBufferSamples = (Settings.SoundPlaybackRate * blockTime) / 1000;
@@ -134,22 +145,57 @@ void CWaveOut::StopPlayback()
     waveOutPause(hWaveOut);
 }
 
+// Bytes actually played since the device was opened, from the driver's play
+// cursor — WOM_DONE arrival can lag this by a full winmm pump period.
+UINT64 CWaveOut::PlayedBytes()
+{
+    MMTIME mmt;
+    mmt.wType = TIME_BYTES;
+    if (!hWaveOut ||
+        waveOutGetPosition(hWaveOut, &mmt, sizeof(mmt)) != MMSYSERR_NOERROR)
+        return playedBytesAccum;
+
+    DWORD pos;
+    if (mmt.wType == TIME_BYTES)
+        pos = mmt.u.cb;
+    else if (mmt.wType == TIME_SAMPLES)
+        pos = mmt.u.sample * (2 * sizeof(int16));
+    else
+        return playedBytesAccum;
+
+    // Unsigned delta handles the DWORD wrap (~6h at 48kHz stereo).
+    playedBytesAccum += (DWORD)(pos - lastPosBytes);
+    lastPosBytes = pos;
+    return playedBytesAccum;
+}
+
 int CWaveOut::GetAvailableBytes()
 {
-    return ((blockCount - bufferCount) * singleBufferBytes) - partialOffset;
+    UINT64 played = PlayedBytes();
+    UINT64 inFlight = (submittedBytes > played) ? submittedBytes - played : 0;
+    if (inFlight > sumBufferSize)
+        inFlight = sumBufferSize;
+    return (int)(sumBufferSize - (UINT32)inFlight) - (int)partialOffset;
 }
 
 // Fill the set of blocks preceding writeOffset with silence and write them
 // to the output to get the buffer back to 50%
 void CWaveOut::RecoverFromUnderrun()
 {
+    // The partial block predates the underrun; letting it play later would
+    // insert a stale-audio blip after the silence cushion.
+    partialOffset = 0;
+
     writeOffset = (writeOffset - (blockCount / 2) + blockCount) % blockCount;
 
     for (int i = 0; i < blockCount / 2; i++)
     {
         memset(waveHeaders[writeOffset].lpData, 0, singleBufferBytes);
-        waveOutWrite(hWaveOut, &waveHeaders[writeOffset], sizeof(WAVEHDR));
-        InterlockedIncrement(&bufferCount);
+        if (waveOutWrite(hWaveOut, &waveHeaders[writeOffset], sizeof(WAVEHDR)) == MMSYSERR_NOERROR)
+        {
+            submittedBytes += singleBufferBytes;
+            InterlockedIncrement(&bufferCount);
+        }
         writeOffset++;
         writeOffset %= blockCount;
     }
@@ -157,10 +203,17 @@ void CWaveOut::RecoverFromUnderrun()
 
 void CWaveOut::ProcessSound()
 {
+    // Cheap lower bound first: bufferCount only lags completions, so this
+    // never overestimates free space. waveOutGetPosition round-trips into
+    // winmm and is far too slow for the per-landing call rate — query the
+    // real cursor only once this bound says the queue may be full.
     int freeBytes = ((blockCount - bufferCount) * singleBufferBytes) - partialOffset;
 
     if (bufferCount == 0)
+    {
         RecoverFromUnderrun();
+        freeBytes = ((blockCount - bufferCount) * singleBufferBytes) - partialOffset;
+    }
 
     if (Settings.DynamicRateControl)
     {
@@ -177,8 +230,12 @@ void CWaveOut::ProcessSound()
         // maintain an accurate measurement.
         if (availableSamples > (freeBytes >> 1))
         {
-            S9xClearSamples();
-            return;
+            freeBytes = GetAvailableBytes();
+            if (availableSamples > (freeBytes >> 1))
+            {
+                S9xClearSamples();
+                return;
+            }
         }
     }
 
@@ -188,14 +245,25 @@ void CWaveOut::ProcessSound()
     if(Settings.SoundSync && !Settings.TurboMode && !Settings.Mute)
     {
         // no sound sync when speed is not set to 100%
+        if ((freeBytes >> 1) < availableSamples)
+            freeBytes = GetAvailableBytes();
+        const DWORD sync_start = timeGetTime();
         while((freeBytes >> 1) < availableSamples)
         {
             ResetEvent(GUI.SoundSyncEvent);
-            if(!GUI.AllowSoundSync || WaitForSingleObject(GUI.SoundSyncEvent, 1000) != WAIT_OBJECT_0)
+            // Space may have freed between the check and the reset — waiting
+            // now would discard that wakeup and oversleep a full block.
+            freeBytes = GetAvailableBytes();
+            if ((freeBytes >> 1) >= availableSamples)
+                break;
+            if (!GUI.AllowSoundSync || timeGetTime() - sync_start > 1000)
             {
                 S9xClearSamples();
                 return;
             }
+            // The event is only a hint; cap the wait so pacing follows the
+            // play cursor, never winmm's lagging callback phase.
+            WaitForSingleObject(GUI.SoundSyncEvent, 4);
             freeBytes = GetAvailableBytes();
         }
     }
@@ -216,8 +284,13 @@ void CWaveOut::ProcessSound()
             S9xMixSamples(offsetBuffer, samplesleftinblock);
             partialOffset = 0;
             availableSamples -= samplesleftinblock;
-            waveOutWrite(hWaveOut, &waveHeaders[writeOffset], sizeof(WAVEHDR));
-            InterlockedIncrement(&bufferCount);
+            // A failed write never gets a WOM_DONE; counting it would leave a
+            // phantom entry that blinds underrun recovery forever.
+            if (waveOutWrite(hWaveOut, &waveHeaders[writeOffset], sizeof(WAVEHDR)) == MMSYSERR_NOERROR)
+            {
+                submittedBytes += singleBufferBytes;
+                InterlockedIncrement(&bufferCount);
+            }
             writeOffset++;
             writeOffset %= blockCount;
         }
@@ -226,8 +299,11 @@ void CWaveOut::ProcessSound()
     while (availableSamples >= singleBufferSamples && bufferCount < blockCount) {
         BYTE *curBuffer = (BYTE *)waveHeaders[writeOffset].lpData;
         S9xMixSamples(curBuffer, singleBufferSamples);
-        waveOutWrite(hWaveOut, &waveHeaders[writeOffset], sizeof(WAVEHDR));
-        InterlockedIncrement(&bufferCount);
+        if (waveOutWrite(hWaveOut, &waveHeaders[writeOffset], sizeof(WAVEHDR)) == MMSYSERR_NOERROR)
+        {
+            submittedBytes += singleBufferBytes;
+            InterlockedIncrement(&bufferCount);
+        }
         writeOffset++;
         writeOffset %= blockCount;
         availableSamples -= singleBufferSamples;

--- a/win32/CWaveOut.h
+++ b/win32/CWaveOut.h
@@ -24,6 +24,12 @@ class CWaveOut : public IS9xSoundOutput
     bool initDone;
 
     volatile LONG bufferCount;
+    // Free space for pacing comes from the device play cursor, not WOM_DONE
+    // arrival — winmm's callback pump can lag playback by a full period.
+    UINT64 submittedBytes;
+    UINT64 playedBytesAccum;
+    DWORD  lastPosBytes;
+    UINT64 PlayedBytes();
     UINT32 sumBufferSize;
     UINT32 singleBufferSamples;
     UINT32 singleBufferBytes;


### PR DESCRIPTION
## Problem

With the WaveOut driver and Sync Sound enabled, a pause/resume perturbation (e.g. opening and closing a menu, which drains the audio queue) can permanently drop the emulator to ~47-49fps with rhythmic audio gaps, until restart. Release builds only in practice — debug timing damps the oscillation — and XAudio2 is unaffected.

## Root cause

The sound-sync throttle paces the emulator on winmm `WOM_DONE` callbacks, but winmm delivers those from an internal pump that can lag the true play cursor by a full period. After the queue drains and refills, the loop can settle into a stable bad phase:

- each sync wait blocks on *callback delivery* rather than *actual playback* (~16ms instead of ~5ms per wait),
- the device silently starves between bursts while `bufferCount > 0` keeps `RecoverFromUnderrun()` blind,
- and the emulator locks to the callback phase at ~80% speed.

Diagnosed by instrumenting `ProcessSound()`: in the degraded state the emulator produced the correct 1066 words/frame but the device completed only 100 of 125 blocks/s, with the accounting never reading empty.

## Fix

- `GetAvailableBytes()` derives in-flight audio from `submittedBytes - waveOutGetPosition()` (wrap-safe), so pacing follows the device, not callback delivery. Because `waveOutGetPosition` round-trips into winmm and `ProcessSound` can run at scanline rate (e.g. an MSU-1 game min()-gates `S9xGetSampleCount()` and keeps the landing threshold satisfied, driving ~15k calls/s), the query is gated behind a cheap `bufferCount`-based bound that can only *under*-estimate free space — the cursor is read only when that bound says the queue may be full, or inside the sync wait itself.
- The sync wait rechecks free space after `ResetEvent` (closing a lost-wakeup race: a `WOM_DONE` landing between the check and the reset had its wakeup discarded) and caps each wait at 4ms; the 1s give-up is kept as total elapsed time.
- `bufferCount`/`submittedBytes` only advance when `waveOutWrite` succeeds — a failed write never gets a `WOM_DONE`, and counting it left a phantom entry that disabled underrun recovery forever.
- `SetupSound()` hard-resets the accounting (`bufferCount` was never initialized in the constructor nor reset across device re-opens).
- `RecoverFromUnderrun()` clears the stale partial block so pre-underrun audio no longer blips out after the silence cushion.

## Verification

Reproduced and verified on Windows 11 with an automated harness (Sound Settings OK + repeated menu open/close at varying cadence, FPS read from the on-screen counter): before the fix the degraded state latched reliably; after, 10/10 campaigns hold 60fps and per-second counters show the device fully fed (125 blocks/s at 48kHz/64ms) with zero dropped samples. The gated cursor query was additionally validated against a min()-gated secondary stream (thread stack sampling had shown the emulator thread saturated inside `winmmbase!waveOutGetPosition` without it).