### PR TITLE
Add support for S-DD1 games converted to run without the chip

### DIFF
--- a/memmap.cpp
+++ b/memmap.cpp
@@ -2248,7 +2248,18 @@ void CMemory::InitROM (void)
 	Map_Initialize();
 	CalculatedChecksum = 0;
 
-	if (HiROM)
+	const bool8	SDD1Decompressed = (CalculatedSize >= 0x800000) &&
+			(Settings.SDD1 ||
+			 strncmp(ROMName, "STREET FIGHTER ALPHA2", 21) == 0 ||
+			 strncmp(ROMName, "STREET FIGHTER ZERO2", 20) == 0 ||
+			 strncmp(ROMName, "Star Ocean", 10) == 0);
+
+	if (SDD1Decompressed)
+	{
+		Settings.SDD1 = FALSE;
+		Map_SDD1DecompressedMap();
+	}
+	else if (HiROM)
 	{
 		if (Settings.BS)
 			/* Do nothing */;
@@ -4054,4 +4065,66 @@ void CMemory::CheckForAnyPatch(const char *rom_filename, bool8 header, int32 &ro
 
     if (try_patch_type_sequence(PATCH_DIR))
         return;
+}
+// Street Fighter Alpha 2 and Star Ocean are the only two S-DD1 cartridges. Both
+// have circulating conversions whose graphics were decompressed ahead of time so
+// that the chip is no longer needed, which is what lets them run from flash
+// cartridges. The decompressed data does not fit the original address space, so
+// the conversions grow the image and address it in two halves: the upper half of
+// each bank sits where LoROM would put it, and the lower half sits one whole
+// image further into the file. Banks $C0 and above are a window composed from the
+// lower halves of two other banks.
+//
+// No real S-DD1 cartridge is larger than Star Ocean's 48 Mbit, so an S-DD1 image
+// at or above 64 Mbit is one of these conversions.
+
+void CMemory::Map_SDD1DecompressedMap (void)
+{
+	const int	banks = (int) (CalculatedSize >> 16);
+
+	map_System();
+
+	for (int bank = 0; bank < 256; bank++)
+	{
+		if (bank == 0x7e || bank == 0x7f)
+			continue;
+
+		uint8	*low, *high;
+
+		if (bank >= 0xc0)
+		{
+			const int	offset = bank - 0xc0;
+
+			if (0x80 + offset >= banks || offset >= banks)
+				continue;
+
+			low  = ROM + (size_t) (0x80 + offset + banks) * 0x8000;
+			high = ROM + (size_t) (offset + banks) * 0x8000 - 0x8000;
+		}
+		else
+		{
+			if (bank >= banks)
+				continue;
+
+			low  = ROM + (size_t) (bank + banks) * 0x8000;
+			high = ROM + (size_t) bank * 0x8000 - 0x8000;
+		}
+
+		for (int block = 0; block < 16; block++)
+		{
+			const bool8	upper_half_only = (bank < 0x40) || (bank >= 0x80 && bank < 0xc0);
+
+			if (block < 8 && upper_half_only)
+				continue;
+
+			const int	slot = (bank << 4) | block;
+
+			Map[slot] = (block < 8) ? low : high;
+			BlockIsROM[slot] = TRUE;
+			BlockIsRAM[slot] = FALSE;
+		}
+	}
+
+	map_WRAM();
+	map_WriteProtectROM();
 }

--- a/memmap.h
+++ b/memmap.h
@@ -156,6 +156,7 @@ struct CMemory
 	void	Map_SuperFXLoROMMap (void);
 	void	Map_SetaDSPLoROMMap (void);
 	void	Map_SDD1LoROMMap (void);
+	void	Map_SDD1DecompressedMap (void);
 	void	Map_SA1LoROMMap (void);
 	void	Map_BSSA1LoROMMap (void);
 	void	Map_HiROMMap (void);


### PR DESCRIPTION
Street Fighter Alpha 2 and Star Ocean are the only S-DD1 cartridges, and both have conversions in circulation whose graphics were decompressed ahead of time so the chip is no longer needed. That is what lets them run from flash cartridges. Neither loads today.

The conversions grow the image and address it in two halves: the upper half of each bank sits where LoROM would put it, and the lower half sits one whole image further into the file. Banks $C0 and above are a window composed from the lower halves of two other banks, which is the part the existing map_lorom and map_hirom_offset helpers cannot express.

Detection has to happen before the HiROM and LoROM split. The Street Fighter Alpha 2 conversion scores as LoROM but Street Fighter Zero 2 scores as HiROM and would otherwise reach Map_ExtendedHiROMMap.

A conversion that keeps the retail header still declares the chip, so Settings.SDD1 alone covers those; no real S-DD1 cartridge exceeds Star Ocean's 48 Mbit, which makes 64 Mbit and above unambiguous. A conversion that corrects its header declares no coprocessor, so those are matched by cartridge name.

Verified against Street Fighter Alpha 2, Street Fighter Zero 2 and Star Ocean conversions at 96 Mbit, and against the retail cartridges of all three, which continue to use Map_SDD1LoROMMap.