### PR TITLE
Name the expanded-cartridge map after its layout, and fix two defects in it

### DIFF
--- a/memmap.cpp
+++ b/memmap.cpp
@@ -2276,7 +2276,24 @@ void CMemory::InitROM (void)
 
 	if (WindowedLoROM)
 	{
+		// This layout provides no coprocessor registers, so one the header still
+		// declares is one the cartridge cannot reach. A conversion keeps the
+		// header of the cartridge it was made from unless somebody went back and
+		// corrected it, and plenty were not, so the byte routinely names the very
+		// part that expanding the data was what removed.
+		//
+		// SuperFX and SA-1 are left alone deliberately. Those run the game's own
+		// code rather than transforming its data, so no amount of expanding ahead
+		// of time removes one, and an image claiming either should not quietly
+		// pass for this layout.
+		Settings.DSP = 0;
+		Settings.C4 = FALSE;
 		Settings.SDD1 = FALSE;
+		Settings.SPC7110 = FALSE;
+		Settings.SPC7110RTC = FALSE;
+		Settings.OBC1 = FALSE;
+		Settings.SETA = 0;
+
 		Map_WindowedLoROMMap();
 	}
 	else if (HiROM)

--- a/memmap.cpp
+++ b/memmap.cpp
@@ -2248,16 +2248,16 @@ void CMemory::InitROM (void)
 	Map_Initialize();
 	CalculatedChecksum = 0;
 
-	const bool8	SDD1Decompressed = (CalculatedSize >= 0x800000) &&
+	const bool8	WindowedLoROM = (CalculatedSize >= 0x800000) &&
 			(Settings.SDD1 ||
 			 strncmp(ROMName, "STREET FIGHTER ALPHA2", 21) == 0 ||
 			 strncmp(ROMName, "STREET FIGHTER ZERO2", 20) == 0 ||
 			 strncmp(ROMName, "Star Ocean", 10) == 0);
 
-	if (SDD1Decompressed)
+	if (WindowedLoROM)
 	{
 		Settings.SDD1 = FALSE;
-		Map_SDD1DecompressedMap();
+		Map_WindowedLoROMMap();
 	}
 	else if (HiROM)
 	{
@@ -4064,19 +4064,24 @@ void CMemory::CheckForAnyPatch(const char *rom_filename, bool8 header, int32 &ro
     if (try_patch_type_sequence(PATCH_DIR))
         return;
 }
-// Street Fighter Alpha 2 and Star Ocean are the only two S-DD1 cartridges. Both
-// have circulating conversions whose graphics were decompressed ahead of time so
-// that the chip is no longer needed, which is what lets them run from flash
-// cartridges. The decompressed data does not fit the original address space, so
-// the conversions grow the image and address it in two halves: the upper half of
-// each bank sits where LoROM would put it, and the lower half sits one whole
-// image further into the file. Banks $C0 and above are a window composed from the
-// lower halves of two other banks.
+// A cartridge whose data was expanded ahead of time so that a coprocessor is no
+// longer needed, which is what lets it run from a flash cartridge or a backup
+// unit. The expanded data does not fit the address space the original used, so
+// the conversion grows the image and addresses it in two planes: the upper half
+// of each bank sits where LoROM would put it, and the lower half sits one whole
+// image further into the file. Banks $C0 and above are a window composed from
+// the lower halves of two other banks.
 //
-// No real S-DD1 cartridge is larger than Star Ocean's 48 Mbit, so an S-DD1 image
-// at or above 64 Mbit is one of these conversions.
+// The layout is a property of the conversion rather than of the chip it removed,
+// and nothing below reads a chipset byte. It was first used for the Star Ocean
+// and Street Fighter Alpha 2 conversions, which dropped an S-DD1, and the same
+// shape serves a cartridge that trades any other coprocessor for room.
+//
+// Banks $00-$3F and $80-$BF give only their upper half, because the lower half
+// belongs to the console. Banks $40-$7D and the window carry a whole 64 KB each,
+// which is what reaches 12 MB where no other layout gets past 8.
 
-void CMemory::Map_SDD1DecompressedMap (void)
+void CMemory::Map_WindowedLoROMMap (void)
 {
 	const int	banks = (int) (CalculatedSize >> 16);
 

--- a/memmap.cpp
+++ b/memmap.cpp
@@ -1396,7 +1396,17 @@ bool8 CMemory::LoadROMInt (int32 ROMfillSize)
 
 	CalculatedSize = ((ROMfillSize + 0x1fff) / 0x2000) * 0x2000;
 
-	if (CalculatedSize > 0x400000 &&
+	// An expanded cartridge is decided by its shape further down and must not be
+	// pre-processed as an extended HiROM on the way there. SMALLFIRST rotates the
+	// ROM buffer in place before InitROM ever runs, and BIGFIRST reads the header
+	// from 0x407FB0, which only lands on one because the conversions in
+	// circulation happen to mirror it there.
+	//
+	// The two Star Ocean conversions escaped this because they kept an S-DD1
+	// chipset byte and the S-DD1 pairs are excluded below. Correcting a header to
+	// declare the coprocessor it no longer has took that protection away, and the
+	// Street Fighter conversions never had it.
+	if (CalculatedSize > 0x400000 && !is_windowed_lorom_size(CalculatedSize) &&
 		(ROM[0x7fd5] + (ROM[0x7fd6] << 8)) != 0x1320 && // exclude SuperFX
 		(ROM[0x7fd5] + (ROM[0x7fd6] << 8)) != 0x1420 &&
 		(ROM[0x7fd5] + (ROM[0x7fd6] << 8)) != 0x1520 &&

--- a/memmap.cpp
+++ b/memmap.cpp
@@ -4165,6 +4165,17 @@ void CMemory::Map_WindowedLoROMMap (void)
 		}
 	}
 
+	// The loop hands banks $70-$7D to cartridge, and that is where LoROM save
+	// memory lives. On hardware the cartridge decodes save RAM there whatever ROM
+	// data sits at the file offset those addresses would otherwise reach, so a
+	// conversion that declares save memory needs the window back.
+	//
+	// Guarded on the declaration because map_LoROMSRAM claims $70-$7D whether or
+	// not there is any save memory, and a conversion that declares none needs
+	// those banks for cartridge.
+	if (SRAMSize > 0)
+		map_LoROMSRAM();
+
 	map_WRAM();
 	map_WriteProtectROM();
 }

--- a/memmap.cpp
+++ b/memmap.cpp
@@ -1347,6 +1347,20 @@ bool8 CMemory::LoadROM (const char *filename)
     return TRUE;
 }
 
+// An expanded cartridge outgrows every layout that could otherwise serve it.
+// Plain LoROM starts mirroring above 4 MB, the extended layouts reach 8 MB, and
+// no retail cartridge ever shipped larger than 6 MB, so an image past 8 MB in a
+// whole number of 64 KB banks is one of these conversions whichever coprocessor
+// it was built to do without. The window addresses 12 MB, which is the ceiling.
+//
+// Recognising the shape rather than a list of titles means a new conversion
+// needs no change here, and stops the code implying that this layout belongs to
+// the one chip the first three happened to remove.
+static bool8 is_windowed_lorom_size (uint32 size)
+{
+	return (size > 0x800000) && (size <= 0xC00000) && ((size & 0xFFFF) == 0);
+}
+
 bool8 CMemory::LoadROMInt (int32 ROMfillSize)
 {
 	Settings.DisplayColor = BUILD_PIXEL(31, 31, 31);
@@ -2248,11 +2262,7 @@ void CMemory::InitROM (void)
 	Map_Initialize();
 	CalculatedChecksum = 0;
 
-	const bool8	WindowedLoROM = (CalculatedSize >= 0x800000) &&
-			(Settings.SDD1 ||
-			 strncmp(ROMName, "STREET FIGHTER ALPHA2", 21) == 0 ||
-			 strncmp(ROMName, "STREET FIGHTER ZERO2", 20) == 0 ||
-			 strncmp(ROMName, "Star Ocean", 10) == 0);
+	const bool8	WindowedLoROM = is_windowed_lorom_size(CalculatedSize);
 
 	if (WindowedLoROM)
 	{

--- a/memmap.h
+++ b/memmap.h
@@ -156,7 +156,7 @@ struct CMemory
 	void	Map_SuperFXLoROMMap (void);
 	void	Map_SetaDSPLoROMMap (void);
 	void	Map_SDD1LoROMMap (void);
-	void	Map_SDD1DecompressedMap (void);
+	void	Map_WindowedLoROMMap (void);
 	void	Map_SA1LoROMMap (void);
 	void	Map_BSSA1LoROMMap (void);
 	void	Map_HiROMMap (void);


### PR DESCRIPTION
Follow-up to #1082. That PR was mine, and the naming I chose in it was wrong. I am sorry for the churn of coming back to the same code so soon.

I called the map `Map_SDD1DecompressedMap` and the flag `SDD1Decompressed`, and I gated it on `Settings.SDD1` plus three ROM titles. All of that says the layout belongs to the S-DD1, and it does not. It is a property of how a conversion re-addresses an image that outgrew the address space, and nothing in the mapping reads a chipset byte. The S-DD1 cartridges were simply the first two anyone had converted. I have since been expanding cartridges that trade a DSP-1 for a lookup table, and they land on exactly the same layout while declaring no coprocessor at all, which is what made the mistake obvious.

While fixing the name I found two defects in what I merged, one of which I introduced and one of which I missed. Both are described below with the measurements behind them.

## What changed

**Renamed to `Map_WindowedLoROMMap`.** The comment above it now describes the layout rather than the two cartridges it came from. No behaviour change in that commit.

**Recognised by shape rather than by title.** Plain LoROM starts mirroring above 4 MB, the extended layouts reach 8 MB, and no retail cartridge ever shipped larger than 6 MB, so an image past 8 MB in whole 64 KB banks and within the 12 MB the window addresses is one of these conversions whatever it dropped. The title list is gone rather than kept as a fallback: it was only needed because my size test was written as 8 MB *or more*, which an ExHiROM image can also be. Past 8 MB nothing else reaches, so the titles buy nothing.

Checked against 7,583 images on hand: the seven conversions are accepted and nothing else is.

**Kept these images out of the ExHiROM rearrangement.** This is the defect I introduced, and it is the serious one. Every image over 4 MB becomes an extended format unless its mapping and chipset bytes match an excluded pair, and the consequences run before `InitROM` chooses a map: `SMALLFIRST` rotates the ROM buffer in place, `BIGFIRST` reads the header from `0x407FB0`.

The two Star Ocean conversions escaped this only because they kept an S-DD1 chipset byte and `0x4532` is excluded. That protection is accidental, and it disappears the moment a conversion corrects its header to stop declaring a chip it does not have. The Street Fighter conversions never had it; they load today because `BIGFIRST` happens to land on a header mirror their builder placed at `0x407FC0`.

**Mapped save memory when a conversion declares it.** This one I missed in #1082. The map gave every bank but `$7E` and `$7F` to cartridge, which covers both LoROM save windows, and never called `map_LoROMSRAM`. Star Ocean declares 8 KB and both conversions inherited the declaration, so **Star Ocean has not been able to save since #1082 merged**. Guarded on the declaration, because `map_LoROMSRAM` claims `$70-$7D` whether or not there is any save memory and the Street Fighter conversions need those banks for cartridge.

I checked that this takes nothing away: in the Star Ocean conversion every one of those banks is 100% filler, because on hardware the cartridge decodes save RAM there and its builder left the space empty.

**Dropped every coprocessor the layout cannot reach, not just the S-DD1.** The map provides no coprocessor registers, so a chip the header still declares is one the cartridge cannot address. It matters most for a DSP, since `Map_LoROMMap` maps DSP registers over cartridge space. SuperFX and SA-1 are deliberately left alone: those run the game's own code rather than transforming its data, so expanding ahead of time cannot remove one.

## How it was tested

Built the libretro core from `master` and from this branch and ran the same images through both, comparing a signature of what each actually drew over 900 frames.

| Image | master | this branch |
|---|---|---|
| Star Ocean conversion, original header | 2,445 colours, save RAM **not mapped** | 2,445 colours, save RAM mapped |
| Star Ocean conversion, corrected header | **2 colours**, `SRAMSize` read as 90 | 2,445 colours, identical signature to the line above |
| Street Fighter Alpha 2 conversion | 323 colours | byte-identical |
| Street Fighter Zero 2 conversion | 355 colours | byte-identical |

A two-colour screen is a black one. The corrected-header image is rotated by the `SMALLFIRST` path on master before anything looks at it, and the header is then read out of the wrong place, which is where `SRAMSize` of 90 comes from.

The frame signature, lit-pixel count and pixel checksum of the corrected image on this branch are identical to the known-good original conversion, and both Street Fighter images are unchanged from master in every figure.

## Context, for anyone who wants to reproduce this

The conversions are not mine. The S-DD1 removal is [neviksti's Star Ocean no S-DD1/96Mbit hack](https://www.romhacking.net/hacks/614/), and the English one is built on DeJap's translation.

Two of my own repositories are what turned this up, in case they are useful to anyone testing:

- [street-fighter-alpha-2-nochip](https://github.com/gufranco/street-fighter-alpha-2-nochip) builds the Street Fighter Alpha 2 and Zero 2 conversions at 96 Mbit.
- [star-ocean-nochip-fix](https://github.com/gufranco/star-ocean-nochip-fix) corrects the Star Ocean conversions' headers, which is what exposed the `ExtendedFormat` problem: the images stop declaring a chip they no longer have, and lose the accidental exclusion that was keeping them off that path.

Neither distributes any image. Thank you for the review, and again, apologies for the naming in the first pass.
