### PR TITLE
gtk: fix AppImage library bundling

### DIFF
--- a/gtk/scripts/makeappimage.sh
+++ b/gtk/scripts/makeappimage.sh
@@ -13,12 +13,12 @@ fi
 DESTDIR=AppDir ninja install
 ./linuxdeploy-x86_64.AppImage --appimage-extract-and-run --appdir=AppDir \
 	--exclude-library="libX*" \
-	--exclude-library="libglib*" \
+	--exclude-library="libglib-2.0.so*" \
 	--exclude-library="libgobject*" \
 	--exclude-library="libgdk_pixbuf*" \
 	--exclude-library="libwayland*" \
 	--exclude-library="libgmodule*" \
-	--exclude-library="libgio*" \
+	--exclude-library="libgio-2.0.so*" \
 	--exclude-library="libxcb*" \
 	--exclude-library="libxkbcommon*" \
 	--exclude-library="libdb*"

--- a/gtk/scripts/makeappimage.sh
+++ b/gtk/scripts/makeappimage.sh
@@ -21,7 +21,16 @@ DESTDIR=AppDir ninja install
 	--exclude-library="libgio-2.0.so*" \
 	--exclude-library="libxcb*" \
 	--exclude-library="libxkbcommon*" \
-	--exclude-library="libdb*"
+	--exclude-library="libdb*" \
+	--exclude-library="libgtk-3.so*" \
+	--exclude-library="libgdk-3.so*" \
+	--exclude-library="libcairo.so*" \
+	--exclude-library="libcairo-gobject.so*" \
+	--exclude-library="libpango-1.0.so*" \
+	--exclude-library="libpangocairo-1.0.so*" \
+	--exclude-library="libpangoft2-1.0.so*" \
+	--exclude-library="libatk-1.0.so*" \
+	--exclude-library="libatk-bridge-2.0.so*"
 
 rm AppDir/snes9x.png
 pushd AppDir


### PR DESCRIPTION
Fixes two library-bundling problems in `gtk/scripts/makeappimage.sh`. Related to #992 and #963.

## Problem 1 — the `libglib*` / `libgio*` globs also match the C++ bindings

`--exclude-library="libglib*"` matches `libglibmm-2.4`, and `--exclude-library="libgio*"` matches `libgiomm-2.4`. Both get dropped from the bundle even though the binary links against them, so the AppImage fails on any host without legacy glibmm installed — which is most current desktops:

```
AppRun: error while loading shared libraries: libgiomm-2.4.so.1:
cannot open shared object file: No such file or directory
```

This affects every build the script produces, on any distro. Anchoring the patterns to `libglib-2.0.so*` / `libgio-2.0.so*` fixes it while still excluding the C libraries as intended.

## Problem 2 — GTK bundled, fontconfig not

linuxdeploy applies the upstream AppImage excludelist, which drops `libfontconfig` and `libfreetype` by design (they read host font configuration). The script bundles `libgtk-3`, `libcairo` and `libpango*` anyway, so the font path is split across bundle and host.

Those libraries are tightly coupled, and a bundle built against one fontconfig can crash on a host with a newer one. The 1.63 release segfaults on Ubuntu 26.04:

```
Fontconfig warning: using without calling FcInit()
AppRun[18872]: segfault at b8 ip 000070f453105953 sp 00007ffd69a10f40 \
  error 4 in libfontconfig.so.1.16.1[2d953,70f4530e0000+31000]
```

Excluding the plain C GTK/pango/cairo/atk stack keeps the whole font path on the host side and internally consistent. The C++ bindings stay bundled, since those are what users are unlikely to have.

## Testing

Ubuntu 26.04, GTK 3.24.52, fontconfig 1.16.1, kernel 7.0.0-30.

| Build | Result |
|---|---|
| Released 1.63 AppImage | `libgiomm` missing; segfault in libfontconfig once that is installed |
| Released 1.63 bundle, GTK/pango/cairo removed by hand | runs |
| master @ 2971061, unpatched script | runs **only** because glibmm-2.4 was installed on the test host; the bundle omits it |
| master @ 2971061, **this patch** | runs |

Worth being explicit about row three: a fresh build on a current distro appears to work, because the bundled GTK then matches host fontconfig and the missing glibmm happens to be present. Neither condition holds for a release artifact on a user's machine, which is why the fix was also verified against the actual 1.63 bundle.

Bundle contents with the patch — `libgtk-3`, `libgdk-3`, `libcairo`, `libpango-1.0`, `libatk-1.0`, `libglib-2.0`, `libgio-2.0` absent; `libglibmm-2.4`, `libgiomm-2.4`, `libgtkmm-3.0`, `libgdkmm-3.0`, `libatkmm-1.6`, `libcairomm-1.0`, `libpangomm-1.4`, `libsigc-2.0` present. 45 libraries, 19 MB (unpatched: 52 libraries, 23 MB).

## Tradeoffs

- Problem 2's fix makes the AppImage require GTK 3 on the host. Present on essentially every desktop Linux, but it is a portability reduction — flagging it in case you'd rather go the other way. The Problem 1 fix has no such tradeoff and stands on its own if you prefer to take only that.
- The alternative for Problem 2 is force-bundling `libfontconfig`/`libfreetype` so the bundle is self-contained. I couldn't test that here: it needs a build on an older base to recreate the skew, and a bundled fontconfig reading a newer host's `/etc/fonts` has its own failure modes.
- Longer term, building the AppImage on the oldest supported distro would reduce skew generally, but that's a CI change rather than something this script can address.