### PR TITLE
bsx: erase the memory pack flash to 0xFF, not 0x00

### DIFF
--- a/bsx.cpp
+++ b/bsx.cpp
@@ -1335,7 +1335,7 @@ void S9xInitBSX (void)
 void S9xResetBSX (void)
 {
 	if (Settings.BSXItself)
-		memset(Memory.ROM, 0, FLASH_SIZE);
+		memset(Memory.ROM, 0xFF, FLASH_SIZE);
 
 	memset(BSX.PPU, 0, sizeof(BSX.PPU));
 	memset(BSX.MMC, 0, sizeof(BSX.MMC));


### PR DESCRIPTION
S9xResetBSX filled the 8M pack with zeros. Flash writes here go through BSX_Set_Bypass_FlashIO, which does `FlashROM[x] = FlashROM[x] & byte`. The AND is right for real flash, where programming can only clear bits. It also means a zero-filled buffer throws away every write made to it. Block Erase and Chip Erase in this same file already write 0xFF.

Nothing reports the failure. S9xGetBSX returns a fixed 0x80 for the Compatible Status Register, so the write looks like it worked. You only find out on a read-back, and the block allocation table lives in the same flash, so that comes back empty too. The download hangs instead of failing.

The buffer is a medium, not scratch space. This memset only runs when Settings.BSXItself is set, meaning the BS-X BIOS was loaded on its own. S9xInitBSX then memmoves the shell into BIOSROM and points FlashROM at Memory.ROM, so Memory.ROM becomes an emulated 8 Mbit Memory Pack. Boot the shell by itself and you get the town with a blank pack already in the slot. This memset is that pack's erase.

It went unnoticed because almost nobody reaches it. The service shut down in 2000, and the usual way to run BS-X in an emulator is to load a .bs file as content, which takes the other branch and never calls this memset. You need the shell booted on its own and a live broadcast arriving to see it.